### PR TITLE
Add harness creator scriptsss creator scripts clean

### DIFF
--- a/skills/harness-creator/scripts/README.md
+++ b/skills/harness-creator/scripts/README.md
@@ -1,0 +1,72 @@
+# Harness Creator Scripts
+
+These scripts provide a minimal CLI layer for the `harness-creator` skill. They are intentionally conservative: they generate harness files, validate harness completeness, and record benchmark evidence, but they do not run or control coding agents directly.
+
+## `create-harness.ts`
+
+Generate a starter harness in a target project directory.
+
+```bash
+npx tsx skills/harness-creator/scripts/create-harness.ts --target ./my-project
+```
+
+Options:
+
+- `--target <path>`: Target project directory. Defaults to the current directory.
+- `--project-name <name>`: Project name used in generated fallback files.
+- `--force`: Overwrite existing harness files.
+- `--help`: Show usage.
+
+Generated files:
+
+- `AGENTS.md`
+- `feature_list.json`
+- `init.sh`
+- `progress.md`
+- `session-handoff.md`
+- `clean-state-checklist.md`
+
+## `validate-harness.ts`
+
+Check whether a target project has the expected harness files and basic state rules.
+
+```bash
+npx tsx skills/harness-creator/scripts/validate-harness.ts --target ./my-project
+```
+
+The validator checks for:
+
+- Required harness files
+- Executable `init.sh`
+- Valid `feature_list.json`
+- At most one active `in_progress` / `in-progress` feature
+- Evidence on completed `passing` / `done` features
+- Core `AGENTS.md` sections
+
+## `run-benchmark.ts`
+
+Create a benchmark evidence folder and optionally run a verification command.
+
+```bash
+npx tsx skills/harness-creator/scripts/run-benchmark.ts \
+  --target ./my-project \
+  --name "debug guard experiment" \
+  --verify-cmd "./init.sh"
+```
+
+Output is written under:
+
+```text
+artifacts/harness-benchmarks/<timestamp>-<benchmark-name>/
+```
+
+Generated files:
+
+- `benchmark-result.json`
+- `benchmark-report.md`
+- `baseline-notes.md`
+- `harness-notes.md`
+
+## Design boundary
+
+`run-benchmark.ts` does not run Claude Code, Codex, Hermes, or other agents. It records the evidence scaffold for comparing a baseline run against a harnessed run. This keeps the script portable and avoids coupling the skill to a specific agent runtime.

--- a/skills/harness-creator/scripts/create-harness.ts
+++ b/skills/harness-creator/scripts/create-harness.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env tsx
+
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+type Options = {
+  target: string
+  force: boolean
+  projectName: string
+}
+
+type TemplateMapping = {
+  template: string
+  output: string
+}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const skillRoot = path.resolve(scriptDir, '..')
+const templateRoot = path.join(skillRoot, 'templates')
+
+const requiredOutputs: TemplateMapping[] = [
+  { template: 'agents.md', output: 'AGENTS.md' },
+  { template: 'feature-list.json', output: 'feature_list.json' },
+  { template: 'init.sh', output: 'init.sh' },
+  { template: 'progress.md', output: 'progress.md' }
+]
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const targetRoot = path.resolve(process.cwd(), options.target)
+
+  await fs.mkdir(targetRoot, { recursive: true })
+
+  const created: string[] = []
+  const skipped: string[] = []
+
+  for (const item of requiredOutputs) {
+    const source = path.join(templateRoot, item.template)
+    const destination = path.join(targetRoot, item.output)
+
+    if (!existsSync(source)) {
+      throw new Error(`Missing template: ${source}`)
+    }
+
+    if (existsSync(destination) && !options.force) {
+      skipped.push(item.output)
+      continue
+    }
+
+    const template = await fs.readFile(source, 'utf-8')
+    const content = customizeContent(template, options)
+
+    await fs.writeFile(destination, content, 'utf-8')
+    created.push(item.output)
+
+    if (item.output === 'init.sh') {
+      await fs.chmod(destination, 0o755)
+    }
+  }
+
+  await writeFallbackIfMissing(
+    path.join(targetRoot, 'session-handoff.md'),
+    buildSessionHandoff(options),
+    options.force,
+    created,
+    skipped
+  )
+
+  await writeFallbackIfMissing(
+    path.join(targetRoot, 'clean-state-checklist.md'),
+    buildCleanStateChecklist(),
+    options.force,
+    created,
+    skipped
+  )
+
+  printSummary(targetRoot, created, skipped)
+}
+
+function parseArgs(args: string[]): Options {
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp()
+    process.exit(0)
+  }
+
+  const target = readFlag(args, '--target') ?? '.'
+  const projectName = readFlag(args, '--project-name') ?? path.basename(path.resolve(target))
+
+  return {
+    target,
+    projectName,
+    force: args.includes('--force')
+  }
+}
+
+function readFlag(args: string[], name: string) {
+  const index = args.indexOf(name)
+  if (index === -1) return null
+  return args[index + 1] ?? null
+}
+
+function customizeContent(content: string, options: Options) {
+  return content
+    .replaceAll('[One-sentence project purpose]', `${options.projectName} project harness.`)
+    .replaceAll('YYYY-MM-DD HH:MM', new Date().toISOString())
+}
+
+async function writeFallbackIfMissing(
+  destination: string,
+  content: string,
+  force: boolean,
+  created: string[],
+  skipped: string[]
+) {
+  const outputName = path.basename(destination)
+
+  if (existsSync(destination) && !force) {
+    skipped.push(outputName)
+    return
+  }
+
+  await fs.writeFile(destination, content, 'utf-8')
+  created.push(outputName)
+}
+
+function buildSessionHandoff(options: Options) {
+  return `# Session Handoff
+
+## Project
+
+${options.projectName}
+
+## Current Verified State
+
+- Standard startup path: \`./init.sh\`
+- Standard verification path: \`./init.sh\`
+- Active feature: TBD
+- Current blocker: None recorded
+
+## This Session Changed
+
+- TBD
+
+## Still Broken or Unverified
+
+- TBD
+
+## Next Best Action
+
+1. Read AGENTS.md.
+2. Read feature_list.json.
+3. Run ./init.sh.
+4. Continue the single active feature only.
+
+## Commands
+
+\`\`\`bash
+./init.sh
+\`\`\`
+`
+}
+
+function buildCleanStateChecklist() {
+  return `# Clean State Checklist
+
+Before ending a session:
+
+- [ ] Standard startup path still works.
+- [ ] Standard verification path has been run.
+- [ ] feature_list.json reflects the real current state.
+- [ ] progress.md has been updated.
+- [ ] session-handoff.md has been updated.
+- [ ] No unrelated files were modified.
+- [ ] No feature is marked passing without evidence.
+- [ ] Next session can resume without asking what happened.
+`
+}
+
+function printHelp() {
+  console.log(`Usage: create-harness.ts [options]
+
+Options:
+  --target <path>        Target project directory. Defaults to current directory.
+  --project-name <name>  Project name used in generated fallback files.
+  --force                Overwrite existing harness files.
+  --help, -h             Show this help.
+`)
+}
+
+function printSummary(targetRoot: string, created: string[], skipped: string[]) {
+  console.log('Harness creation complete.')
+  console.log(`Target: ${targetRoot}`)
+  console.log('')
+
+  if (created.length > 0) {
+    console.log('Created:')
+    for (const file of created) console.log(`- ${file}`)
+  }
+
+  if (skipped.length > 0) {
+    console.log('')
+    console.log('Skipped existing files:')
+    for (const file of skipped) console.log(`- ${file}`)
+    console.log('')
+    console.log('Use --force to overwrite existing files.')
+  }
+
+  console.log('')
+  console.log('Next steps:')
+  console.log('1. Review AGENTS.md and replace placeholders.')
+  console.log('2. Edit feature_list.json for the real project features.')
+  console.log('3. Run ./init.sh from the target project.')
+  console.log('4. Run validate-harness.ts to check completeness.')
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/skills/harness-creator/scripts/run-benchmark.ts
+++ b/skills/harness-creator/scripts/run-benchmark.ts
@@ -1,0 +1,240 @@
+#!/usr/bin/env tsx
+
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import { spawn } from 'node:child_process'
+
+type Options = {
+  target: string
+  name: string
+  verifyCommand: string | null
+}
+
+type CommandResult = {
+  command: string
+  exitCode: number | null
+  stdout: string
+  stderr: string
+  durationMs: number
+}
+
+type BenchmarkResult = {
+  name: string
+  target: string
+  createdAt: string
+  verify?: CommandResult
+  notes: string[]
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp()
+    return
+  }
+
+  const options = parseArgs(args)
+  const target = path.resolve(process.cwd(), options.target)
+  const timestamp = new Date().toISOString().replaceAll(':', '-').replaceAll('.', '-')
+  const outputDir = path.join(target, 'artifacts', 'harness-benchmarks', `${timestamp}-${slug(options.name)}`)
+
+  await fs.mkdir(outputDir, { recursive: true })
+
+  const result: BenchmarkResult = {
+    name: options.name,
+    target,
+    createdAt: new Date().toISOString(),
+    notes: [
+      'This script records benchmark evidence.',
+      'It does not run Claude Code, Codex, Hermes, or any other coding agent by itself.',
+      'Run the same task manually in baseline and harness conditions, then attach logs here.'
+    ]
+  }
+
+  if (options.verifyCommand) {
+    result.verify = await runCommand(options.verifyCommand, target)
+  }
+
+  await fs.writeFile(
+    path.join(outputDir, 'benchmark-result.json'),
+    JSON.stringify(result, null, 2),
+    'utf-8'
+  )
+
+  await fs.writeFile(path.join(outputDir, 'benchmark-report.md'), buildMarkdownReport(result), 'utf-8')
+  await fs.writeFile(path.join(outputDir, 'baseline-notes.md'), buildRunNotes('Baseline run'), 'utf-8')
+  await fs.writeFile(path.join(outputDir, 'harness-notes.md'), buildRunNotes('Harness run'), 'utf-8')
+
+  console.log('Benchmark scaffold created:')
+  console.log(outputDir)
+
+  if (result.verify) {
+    console.log('')
+    console.log(`Verification command: ${result.verify.command}`)
+    console.log(`Exit code: ${result.verify.exitCode}`)
+  }
+}
+
+function parseArgs(args: string[]): Options {
+  return {
+    target: readFlag(args, '--target') ?? '.',
+    name: readFlag(args, '--name') ?? 'harness-benchmark',
+    verifyCommand: readFlag(args, '--verify-cmd')
+  }
+}
+
+function readFlag(args: string[], name: string) {
+  const index = args.indexOf(name)
+  if (index === -1) return null
+  return args[index + 1] ?? null
+}
+
+async function runCommand(command: string, cwd: string): Promise<CommandResult> {
+  const startedAt = Date.now()
+
+  return await new Promise((resolve) => {
+    const child = spawn(command, {
+      cwd,
+      shell: true,
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString()
+    })
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString()
+    })
+
+    child.on('close', (exitCode) => {
+      resolve({
+        command,
+        exitCode,
+        stdout,
+        stderr,
+        durationMs: Date.now() - startedAt
+      })
+    })
+  })
+}
+
+function buildMarkdownReport(result: BenchmarkResult) {
+  return `# Harness Benchmark Report
+
+## Benchmark
+
+- Name: ${result.name}
+- Target: ${result.target}
+- Created at: ${result.createdAt}
+
+## What This Measures
+
+Compare the same task under two conditions:
+
+1. Baseline: weak or no harness
+2. Harness: AGENTS.md, feature_list.json, init.sh, progress.md, and verification rules in place
+
+## Metrics
+
+| Metric | Baseline | Harness |
+|---|---:|---:|
+| Task completed | TBD | TBD |
+| Verification passed | TBD | TBD |
+| Time spent | TBD | TBD |
+| Rework required | TBD | TBD |
+| Unrelated files changed | TBD | TBD |
+| Human intervention count | TBD | TBD |
+
+## Verification Snapshot
+
+${result.verify ? `Command: \`${result.verify.command}\`
+
+Exit code: \`${result.verify.exitCode}\`
+
+Duration: \`${result.verify.durationMs}ms\`
+
+### stdout
+
+\`\`\`text
+${trimForMarkdown(result.verify.stdout)}
+\`\`\`
+
+### stderr
+
+\`\`\`text
+${trimForMarkdown(result.verify.stderr)}
+\`\`\`
+` : 'No verification command was run by this script.'}
+
+## Notes
+
+${result.notes.map((note) => `- ${note}`).join('\n')}
+`
+}
+
+function buildRunNotes(title: string) {
+  return `# ${title}
+
+## Task Prompt
+
+TBD
+
+## Setup
+
+- Branch:
+- Commit:
+- Agent:
+- Model:
+- Time budget:
+- Turn budget:
+
+## Result
+
+- Completed:
+- Verification command:
+- Verification result:
+- Human intervention:
+- Unrelated changes:
+
+## Evidence
+
+Paste logs, screenshots, command output, and final diff notes here.
+
+## Observations
+
+TBD
+`
+}
+
+function trimForMarkdown(value: string) {
+  const max = 12000
+  if (value.length <= max) return value
+  return `${value.slice(0, max)}\n\n[truncated ${value.length - max} characters]`
+}
+
+function slug(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9\u4e00-\u9fa5]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function printHelp() {
+  console.log(`Usage: run-benchmark.ts [options]
+
+Options:
+  --target <path>       Target project directory. Defaults to current directory.
+  --name <name>         Benchmark name. Defaults to harness-benchmark.
+  --verify-cmd <cmd>    Optional verification command to run and record.
+  --help, -h            Show this help.
+`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/skills/harness-creator/scripts/validate-harness.ts
+++ b/skills/harness-creator/scripts/validate-harness.ts
@@ -1,0 +1,199 @@
+#!/usr/bin/env tsx
+
+import path from 'node:path'
+import { promises as fs } from 'node:fs'
+import { existsSync, statSync } from 'node:fs'
+
+type CheckResult = {
+  name: string
+  ok: boolean
+  message: string
+}
+
+type Feature = {
+  id?: string
+  name?: string
+  title?: string
+  status?: string
+  evidence?: string
+  verification?: unknown
+}
+
+type FeatureList = {
+  features?: Feature[]
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  if (args.includes('--help') || args.includes('-h')) {
+    printHelp()
+    return
+  }
+
+  const target = path.resolve(process.cwd(), readFlag(args, '--target') ?? '.')
+  const results: CheckResult[] = []
+
+  results.push(checkExists(target, 'AGENTS.md'))
+  results.push(checkExists(target, 'feature_list.json'))
+  results.push(checkExists(target, 'init.sh'))
+  results.push(checkExists(target, 'progress.md'))
+  results.push(checkExists(target, 'session-handoff.md'))
+  results.push(checkExists(target, 'clean-state-checklist.md'))
+  results.push(checkExecutable(target, 'init.sh'))
+
+  const featureListPath = path.join(target, 'feature_list.json')
+  if (existsSync(featureListPath)) {
+    results.push(...await checkFeatureList(featureListPath))
+  }
+
+  const agentsPath = path.join(target, 'AGENTS.md')
+  if (existsSync(agentsPath)) {
+    results.push(...await checkAgentsFile(agentsPath))
+  }
+
+  printResults(target, results)
+
+  if (results.some((result) => !result.ok)) {
+    process.exitCode = 1
+  }
+}
+
+function readFlag(args: string[], name: string) {
+  const index = args.indexOf(name)
+  if (index === -1) return null
+  return args[index + 1] ?? null
+}
+
+function checkExists(target: string, file: string): CheckResult {
+  const fullPath = path.join(target, file)
+  const exists = existsSync(fullPath)
+
+  return {
+    name: `exists:${file}`,
+    ok: exists,
+    message: exists ? `${file} exists` : `${file} is missing`
+  }
+}
+
+function checkExecutable(target: string, file: string): CheckResult {
+  const fullPath = path.join(target, file)
+
+  if (!existsSync(fullPath)) {
+    return {
+      name: `executable:${file}`,
+      ok: false,
+      message: `${file} is missing`
+    }
+  }
+
+  const mode = statSync(fullPath).mode
+  const executable = (mode & 0o111) !== 0
+
+  return {
+    name: `executable:${file}`,
+    ok: executable,
+    message: executable ? `${file} is executable` : `${file} is not executable. Run chmod +x ${file}`
+  }
+}
+
+async function checkFeatureList(filePath: string): Promise<CheckResult[]> {
+  const results: CheckResult[] = []
+
+  try {
+    const parsed = JSON.parse(await fs.readFile(filePath, 'utf-8')) as FeatureList
+    const features = parsed.features ?? []
+
+    results.push({
+      name: 'feature_list:valid_json',
+      ok: true,
+      message: 'feature_list.json is valid JSON'
+    })
+
+    results.push({
+      name: 'feature_list:has_features',
+      ok: Array.isArray(features) && features.length > 0,
+      message: features.length > 0 ? `feature_list.json has ${features.length} features` : 'feature_list.json has no features'
+    })
+
+    const active = features.filter((feature) => feature.status === 'in_progress' || feature.status === 'in-progress')
+    results.push({
+      name: 'feature_list:wip_limit',
+      ok: active.length <= 1,
+      message: active.length <= 1 ? 'WIP limit ok: at most one active feature' : `WIP limit violated: ${active.length} active features`
+    })
+
+    const missingId = features.filter((feature) => !feature.id)
+    results.push({
+      name: 'feature_list:ids',
+      ok: missingId.length === 0,
+      message: missingId.length === 0 ? 'All features have ids' : `${missingId.length} feature(s) missing id`
+    })
+
+    const completedWithoutEvidence = features.filter((feature) => {
+      const status = feature.status
+      return (status === 'passing' || status === 'done') && !feature.evidence
+    })
+
+    results.push({
+      name: 'feature_list:evidence',
+      ok: completedWithoutEvidence.length === 0,
+      message: completedWithoutEvidence.length === 0
+        ? 'No completed feature is missing evidence'
+        : `${completedWithoutEvidence.length} completed feature(s) missing evidence`
+    })
+  } catch (error) {
+    results.push({
+      name: 'feature_list:valid_json',
+      ok: false,
+      message: `feature_list.json is invalid: ${error instanceof Error ? error.message : String(error)}`
+    })
+  }
+
+  return results
+}
+
+async function checkAgentsFile(filePath: string): Promise<CheckResult[]> {
+  const content = await fs.readFile(filePath, 'utf-8')
+  const requiredPhrases = ['Startup Workflow', 'Working Rules', 'Definition of Done', 'End of Session']
+
+  return requiredPhrases.map((phrase) => ({
+    name: `AGENTS.md:${phrase}`,
+    ok: content.includes(phrase),
+    message: content.includes(phrase) ? `AGENTS.md contains ${phrase}` : `AGENTS.md missing ${phrase}`
+  }))
+}
+
+function printHelp() {
+  console.log(`Usage: validate-harness.ts [options]
+
+Options:
+  --target <path>  Target project directory. Defaults to current directory.
+  --help, -h       Show this help.
+`)
+}
+
+function printResults(target: string, results: CheckResult[]) {
+  console.log('Harness validation results:')
+  console.log(`Target: ${target}`)
+  console.log('')
+
+  for (const result of results) {
+    const marker = result.ok ? 'PASS' : 'FAIL'
+    console.log(`[${marker}] ${result.name}: ${result.message}`)
+  }
+
+  console.log('')
+  const passed = results.filter((result) => result.ok).length
+  const total = results.length
+  console.log(`Score: ${passed}/${total}`)
+
+  if (passed !== total) {
+    console.log('')
+    console.log('Fix failed checks before relying on this harness.')
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary

Adds a minimal CLI layer for the `harness-creator` skill:

- `create-harness.ts` generates starter harness files in a target project.
- `validate-harness.ts` checks required harness files and basic state rules.
- `run-benchmark.ts` creates benchmark evidence folders and optionally records a verification command result.
- `scripts/README.md` documents usage and design boundaries.

## Design notes

The scripts are intentionally conservative. They generate, validate, and record evidence, but they do not run or control Claude Code, Codex, Hermes, or any other coding agent directly. This keeps the skill portable across agent runtimes.

## Testing

Not run in this environment. The changes are standalone TypeScript CLI scripts and documentation under `skills/harness-creator/scripts/`.