### PR TITLE
fix: mermaid zoom modal respects dark mode

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -644,7 +644,7 @@ html.has-mermaid-viewer body {
 .mermaid-viewer__backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(250, 249, 245, 0.96);
+  background: var(--vp-c-bg);
 }
 
 .mermaid-viewer__panel {
@@ -670,12 +670,17 @@ html.has-mermaid-viewer body {
   border-radius: 999px;
   width: 40px;
   height: 40px;
-  background: rgba(0, 0, 0, 0.06);
+  background: var(--vp-c-bg-soft);
   color: var(--vp-c-text-1);
   font-size: 24px;
   line-height: 1;
   font-weight: 400;
   cursor: pointer;
+}
+
+.mermaid-viewer__tool:hover,
+.mermaid-viewer__close:hover {
+  background: var(--vp-c-bg-mute);
 }
 
 .mermaid-viewer__tool--label {
@@ -694,7 +699,7 @@ html.has-mermaid-viewer body {
   justify-content: center;
   padding: 8px;
   cursor: zoom-out;
-  background: #fff;
+  background: var(--vp-c-bg);
 }
 
 .mermaid-viewer__stage {

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -680,7 +680,7 @@ html.has-mermaid-viewer body {
 
 .mermaid-viewer__tool:hover,
 .mermaid-viewer__close:hover {
-  background: var(--vp-c-bg-mute);
+  background: var(--vp-c-bg-elv);
 }
 
 .mermaid-viewer__tool--label {


### PR DESCRIPTION
## Summary

The Mermaid diagram zoom modal in `docs/.vitepress/theme/style.css` had hardcoded light colors that looked jarring when the site is in dark mode:

- `.mermaid-viewer__backdrop` background → `rgba(250, 249, 245, 0.96)` (light beige)
- `.mermaid-viewer__body` background → `#fff`
- `.mermaid-viewer__tool` / `__close` background → `rgba(0, 0, 0, 0.06)` (near-invisible on dark)

Replaced with VitePress design tokens so the modal chrome adapts to whatever theme is active:

- Backdrop + body → `var(--vp-c-bg)`
- Tool / close buttons → `var(--vp-c-bg-soft)` resting, `var(--vp-c-bg-elv)` on hover
- No `.dark .selector` overrides — the tokens already adapt in both `:root` and `.dark`

Touches `docs/.vitepress/theme/style.css` only. No JS changes, no config changes.

## Out of scope

Re-theming the Mermaid SVG diagram content (node fills, edge labels) for dark mode. The diagram itself still renders with the hardcoded `themeVariables` in `config.mts`, so the SVG stays light-themed inside a dark modal — visible mismatch but a separate, larger change. Tracking it separately.

## Before / After

### Before

<img width="2880" height="1468" alt="mermaid-zoom-dark-mode-BEFORE-dark" src="https://github.com/user-attachments/assets/cfbeab9f-0636-47ca-a2c8-c0ab3768c89c" />

### After

<img width="2880" height="1468" alt="mermaid-zoom-dark-mode-dark" src="https://github.com/user-attachments/assets/e00c04fc-c77f-4e24-8dfe-c430a0ad1920" />
 
## Test plan

- [x] `npm run docs:build` green
- [x] Dark mode: backdrop + body + buttons all dark
- [x] Light mode: visually identical to before (`#fff` → `var(--vp-c-bg)` = `#fffefb`, imperceptible)
- [x] Hover on `−` / `100%` / `+` / `×` buttons gives a visible elevated background