### PR TITLE
docs(projects): add bilingual project readmes

### DIFF
--- a/projects/project-01/README-CN.md
+++ b/projects/project-01/README-CN.md
@@ -1,0 +1,42 @@
+# Project 01: Baseline vs Minimal Harness
+
+比较弱 harness（仅靠 prompt）和显式 harness（规则文件 + 验证机制）对 AI 编码代理任务完成率的影响。
+
+## 目录说明
+
+| 目录 | 含义 |
+|------|------|
+| `starter/` | **起点**——只有一个模糊的 `task-prompt.md`，没有 AGENTS.md、没有 feature_list.json。这是你给代理的"弱 harness"版本。 |
+| `solution/` | **参考实现**——相同的应用代码，但配备了完整的 harness 文件（AGENTS.md、feature_list.json、init.sh、claude-progress.md）。这是"显式 harness"版本。 |
+
+## 使用方法
+
+```sh
+# 1. 用 starter（弱 harness）跑一次代理任务
+cd starter
+npm install
+# 把 task-prompt.md 的内容作为 prompt 给 Claude Code / Codex
+# 让代理尝试完成：窗口启动、文档列表、问答面板、数据目录
+
+# 2. 用 solution（显式 harness）跑一次
+cd ../solution
+npm install
+# 让代理读取 AGENTS.md，按规则执行同样的任务
+
+# 3. 对比两次结果
+# - 任务是否完成？
+# - 需要重试几次？
+# - 代理是否提前声称"完成"？
+```
+
+## 本项目涉及的功能
+
+- Electron 窗口成功启动
+- UI 显示文档列表区域
+- UI 显示问答面板
+- 应用创建并使用本地数据目录
+
+## 对应课件
+
+- [Lecture 01: 为什么强大的模型仍然会失败](../../docs/lectures/lecture-01-why-capable-agents-still-fail/index.md)
+- [Lecture 02: Harness 到底是什么](../../docs/lectures/lecture-02-what-a-harness-actually-is/index.md)

--- a/projects/project-01/README.md
+++ b/projects/project-01/README.md
@@ -1,42 +1,42 @@
 # Project 01: Baseline vs Minimal Harness
 
-比较弱 harness（仅靠 prompt）和显式 harness（规则文件 + 验证机制）对 AI 编码代理任务完成率的影响。
+Compare how a weak harness (prompt only) and an explicit harness (rule files plus verification mechanisms) affect the completion rate of AI coding-agent tasks.
 
-## 目录说明
+## Directory Guide
 
-| 目录 | 含义 |
+| Directory | Meaning |
 |------|------|
-| `starter/` | **起点**——只有一个模糊的 `task-prompt.md`，没有 AGENTS.md、没有 feature_list.json。这是你给代理的"弱 harness"版本。 |
-| `solution/` | **参考实现**——相同的应用代码，但配备了完整的 harness 文件（AGENTS.md、feature_list.json、init.sh、claude-progress.md）。这是"显式 harness"版本。 |
+| `starter/` | **Starting point**: only a vague `task-prompt.md`, with no AGENTS.md and no feature_list.json. This is the "weak harness" version you give to the agent. |
+| `solution/` | **Reference implementation**: the same application code, but with complete harness files (AGENTS.md, feature_list.json, init.sh, claude-progress.md). This is the "explicit harness" version. |
 
-## 使用方法
+## How to Use
 
 ```sh
-# 1. 用 starter（弱 harness）跑一次代理任务
+# 1. Run the agent task once with starter (weak harness)
 cd starter
 npm install
-# 把 task-prompt.md 的内容作为 prompt 给 Claude Code / Codex
-# 让代理尝试完成：窗口启动、文档列表、问答面板、数据目录
+# Give the contents of task-prompt.md as the prompt to Claude Code / Codex
+# Ask the agent to complete: window startup, document list, QA panel, data directory
 
-# 2. 用 solution（显式 harness）跑一次
+# 2. Run the same task with solution (explicit harness)
 cd ../solution
 npm install
-# 让代理读取 AGENTS.md，按规则执行同样的任务
+# Ask the agent to read AGENTS.md and follow the rules for the same task
 
-# 3. 对比两次结果
-# - 任务是否完成？
-# - 需要重试几次？
-# - 代理是否提前声称"完成"？
+# 3. Compare the two results
+# - Was the task completed?
+# - How many retries were needed?
+# - Did the agent claim "done" too early?
 ```
 
-## 本项目涉及的功能
+## Features Covered
 
-- Electron 窗口成功启动
-- UI 显示文档列表区域
-- UI 显示问答面板
-- 应用创建并使用本地数据目录
+- Electron window starts successfully
+- UI shows the document-list area
+- UI shows the QA panel
+- App creates and uses a local data directory
 
-## 对应课件
+## Related Lectures
 
-- [Lecture 01: 为什么强大的模型仍然会失败](../../docs/lectures/lecture-01-why-capable-agents-still-fail/index.md)
-- [Lecture 02: Harness 到底是什么](../../docs/lectures/lecture-02-what-a-harness-actually-is/index.md)
+- [Lecture 01: Why Capable Agents Still Fail](../../docs/en/lectures/lecture-01-why-capable-agents-still-fail/index.md)
+- [Lecture 02: What a Harness Actually Is](../../docs/en/lectures/lecture-02-what-a-harness-actually-is/index.md)

--- a/projects/project-02/README-CN.md
+++ b/projects/project-02/README-CN.md
@@ -1,0 +1,35 @@
+# Project 02: Agent-Readable Workspace
+
+演示仓库可读性和显式连续性产物如何减少跨会话开发中的上下文丢失。
+
+## 目录说明
+
+| 目录 | 含义 |
+|------|------|
+| `starter/` | **起点**——基于 P1 solution 的代码，新增文档导入、详情视图、持久化功能待实现。harness 较弱：AGENTS.md 简陋，没有 session-handoff。 |
+| `solution/` | **参考实现**——所有新功能已实现，配备完整的 workspace 文档（ARCHITECTURE.md、PRODUCT.md、session-handoff.md）。 |
+
+## 使用方法
+
+```sh
+# 需要至少 2 个 agent 会话来完成
+cd starter
+npm install
+# Session A: 实现文档导入和详情视图
+# Session B: 实现持久化（观察 agent 能否快速恢复上下文）
+
+cd ../solution
+npm install
+# 用完整 harness 重跑，对比会话恢复速度
+```
+
+## 本项目涉及的功能
+
+- 文档导入流程（文件选择器 + IPC 传输）
+- 文档详情视图（元数据 + 内容展示）
+- 基本持久化（导入的文档在重启后保留）
+
+## 对应课件
+
+- [Lecture 03: 让仓库成为唯一的真相来源](../../docs/lectures/lecture-03-why-the-repository-must-become-the-system-of-record/index.md)
+- [Lecture 04: 拆分指令文件，而不是一个巨型文件](../../docs/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md)

--- a/projects/project-02/README.md
+++ b/projects/project-02/README.md
@@ -1,35 +1,35 @@
 # Project 02: Agent-Readable Workspace
 
-演示仓库可读性和显式连续性产物如何减少跨会话开发中的上下文丢失。
+Demonstrate how repository readability and explicit continuity artifacts reduce context loss during multi-session development.
 
-## 目录说明
+## Directory Guide
 
-| 目录 | 含义 |
+| Directory | Meaning |
 |------|------|
-| `starter/` | **起点**——基于 P1 solution 的代码，新增文档导入、详情视图、持久化功能待实现。harness 较弱：AGENTS.md 简陋，没有 session-handoff。 |
-| `solution/` | **参考实现**——所有新功能已实现，配备完整的 workspace 文档（ARCHITECTURE.md、PRODUCT.md、session-handoff.md）。 |
+| `starter/` | **Starting point**: based on the P1 solution, with document import, detail view, and persistence still to implement. The harness is weak: AGENTS.md is minimal and there is no session handoff. |
+| `solution/` | **Reference implementation**: all new features are implemented, with complete workspace documentation (ARCHITECTURE.md, PRODUCT.md, session-handoff.md). |
 
-## 使用方法
+## How to Use
 
 ```sh
-# 需要至少 2 个 agent 会话来完成
+# Requires at least 2 agent sessions to complete
 cd starter
 npm install
-# Session A: 实现文档导入和详情视图
-# Session B: 实现持久化（观察 agent 能否快速恢复上下文）
+# Session A: implement document import and the detail view
+# Session B: implement persistence (observe whether the agent quickly regains context)
 
 cd ../solution
 npm install
-# 用完整 harness 重跑，对比会话恢复速度
+# Rerun with the complete harness and compare session recovery speed
 ```
 
-## 本项目涉及的功能
+## Features Covered
 
-- 文档导入流程（文件选择器 + IPC 传输）
-- 文档详情视图（元数据 + 内容展示）
-- 基本持久化（导入的文档在重启后保留）
+- Document import flow (file picker plus IPC transfer)
+- Document detail view (metadata plus content display)
+- Basic persistence (imported documents remain after restart)
 
-## 对应课件
+## Related Lectures
 
-- [Lecture 03: 让仓库成为唯一的真相来源](../../docs/lectures/lecture-03-why-the-repository-must-become-the-system-of-record/index.md)
-- [Lecture 04: 拆分指令文件，而不是一个巨型文件](../../docs/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md)
+- [Lecture 03: Why the Repository Must Become the System of Record](../../docs/en/lectures/lecture-03-why-the-repository-must-become-the-system-of-record/index.md)
+- [Lecture 04: Why One Giant Instruction File Fails](../../docs/en/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md)

--- a/projects/project-03/README-CN.md
+++ b/projects/project-03/README-CN.md
@@ -1,0 +1,34 @@
+# Project 03: Scope Control and Grounded Verification
+
+评估显式范围控制和验证门控是否能提高交付准确性。
+
+## 目录说明
+
+| 目录 | 含义 |
+|------|------|
+| `starter/` | **起点**——基于 P2 solution，新增文档分块、元数据提取、索引状态、基础问答功能待实现。没有一次一个功能的策略约束。 |
+| `solution/` | **参考实现**——所有功能已实现，AGENTS.md 包含"一次一个功能"策略，feature_list.json 展示 fail→pass 的转换过程和验证证据。 |
+
+## 使用方法
+
+```sh
+cd starter
+npm install
+# 观察 agent 是否会同时实现多个功能（范围漂移）
+
+cd ../solution
+npm install
+# 用 scope control 重跑，对比功能交付准确性
+```
+
+## 本项目涉及的功能
+
+- 文档分块（段落感知，~500 字符）
+- 元数据提取（词数、行数、段落数）
+- 索引状态在 UI 中显示
+- 基础问答流程，带来源引用
+
+## 对应课件
+
+- [Lecture 05: 保持跨会话上下文](../../docs/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md)
+- [Lecture 06: 每次会话前先初始化](../../docs/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md)

--- a/projects/project-03/README.md
+++ b/projects/project-03/README.md
@@ -1,34 +1,34 @@
 # Project 03: Scope Control and Grounded Verification
 
-评估显式范围控制和验证门控是否能提高交付准确性。
+Evaluate whether explicit scope control and verification gates improve delivery accuracy.
 
-## 目录说明
+## Directory Guide
 
-| 目录 | 含义 |
+| Directory | Meaning |
 |------|------|
-| `starter/` | **起点**——基于 P2 solution，新增文档分块、元数据提取、索引状态、基础问答功能待实现。没有一次一个功能的策略约束。 |
-| `solution/` | **参考实现**——所有功能已实现，AGENTS.md 包含"一次一个功能"策略，feature_list.json 展示 fail→pass 的转换过程和验证证据。 |
+| `starter/` | **Starting point**: based on the P2 solution, with document chunking, metadata extraction, index status, and basic QA still to implement. There is no "one feature at a time" strategy constraint. |
+| `solution/` | **Reference implementation**: all features are implemented. AGENTS.md includes a "one feature at a time" strategy, and feature_list.json shows the fail-to-pass transition and verification evidence. |
 
-## 使用方法
+## How to Use
 
 ```sh
 cd starter
 npm install
-# 观察 agent 是否会同时实现多个功能（范围漂移）
+# Observe whether the agent implements multiple features at once (scope drift)
 
 cd ../solution
 npm install
-# 用 scope control 重跑，对比功能交付准确性
+# Rerun with scope control and compare feature delivery accuracy
 ```
 
-## 本项目涉及的功能
+## Features Covered
 
-- 文档分块（段落感知，~500 字符）
-- 元数据提取（词数、行数、段落数）
-- 索引状态在 UI 中显示
-- 基础问答流程，带来源引用
+- Document chunking (paragraph-aware, about 500 characters)
+- Metadata extraction (word count, line count, paragraph count)
+- Index status displayed in the UI
+- Basic QA flow with source citations
 
-## 对应课件
+## Related Lectures
 
-- [Lecture 05: 保持跨会话上下文](../../docs/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md)
-- [Lecture 06: 每次会话前先初始化](../../docs/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md)
+- [Lecture 05: Why Long-Running Tasks Lose Continuity](../../docs/en/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md)
+- [Lecture 06: Why Initialization Needs Its Own Phase](../../docs/en/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md)

--- a/projects/project-04/README-CN.md
+++ b/projects/project-04/README-CN.md
@@ -1,0 +1,36 @@
+# Project 04: Runtime Observability and Structural Control
+
+引入运行时可观测性和结构化边界检查，同时调试一个植入的运行时缺陷。
+
+## 目录说明
+
+| 目录 | 含义 |
+|------|------|
+| `starter/` | **起点**——基于 P3 solution，新增日志、结构化边界功能待实现。`IndexingService` 中植入了一个隐蔽 bug：超过 1000 字符的文件会产生空分块。没有架构检查脚本。 |
+| `solution/` | **参考实现**——结构化日志模块、架构边界检查脚本、植入 bug 已修复。 |
+
+## 使用方法
+
+```sh
+cd starter
+npm install
+# 1. 观察 agent 能否通过日志定位 bug
+# 2. 导入一个大文件，观察分块结果是否异常
+
+cd ../solution
+npm install
+# 对比：结构化日志如何加速问题诊断
+```
+
+## 本项目涉及的功能
+
+- 启动日志
+- 导入和索引日志
+- 可见的问答失败路径
+- main / preload / renderer / services 层的显式边界
+- 调试一个植入的运行时缺陷
+
+## 对应课件
+
+- [Lecture 07: 给代理划定清晰的任务边界](../../docs/lectures/lecture-07-why-agents-overreach-and-under-finish/index.md)
+- [Lecture 08: 用功能列表约束代理行为](../../docs/lectures/lecture-08-why-feature-lists-are-harness-primitives/index.md)

--- a/projects/project-04/README.md
+++ b/projects/project-04/README.md
@@ -1,36 +1,36 @@
 # Project 04: Runtime Observability and Structural Control
 
-引入运行时可观测性和结构化边界检查，同时调试一个植入的运行时缺陷。
+Introduce runtime observability and structural boundary checks while debugging a seeded runtime defect.
 
-## 目录说明
+## Directory Guide
 
-| 目录 | 含义 |
+| Directory | Meaning |
 |------|------|
-| `starter/` | **起点**——基于 P3 solution，新增日志、结构化边界功能待实现。`IndexingService` 中植入了一个隐蔽 bug：超过 1000 字符的文件会产生空分块。没有架构检查脚本。 |
-| `solution/` | **参考实现**——结构化日志模块、架构边界检查脚本、植入 bug 已修复。 |
+| `starter/` | **Starting point**: based on the P3 solution, with logging and structural boundary features still to implement. `IndexingService` contains a hidden seeded bug: files longer than 1000 characters produce empty chunks. There is no architecture-check script. |
+| `solution/` | **Reference implementation**: structured logging module, architecture boundary-check script, and the seeded bug fixed. |
 
-## 使用方法
+## How to Use
 
 ```sh
 cd starter
 npm install
-# 1. 观察 agent 能否通过日志定位 bug
-# 2. 导入一个大文件，观察分块结果是否异常
+# 1. Observe whether the agent can locate the bug through logs
+# 2. Import a large file and check whether chunking behaves incorrectly
 
 cd ../solution
 npm install
-# 对比：结构化日志如何加速问题诊断
+# Compare how structured logs speed up diagnosis
 ```
 
-## 本项目涉及的功能
+## Features Covered
 
-- 启动日志
-- 导入和索引日志
-- 可见的问答失败路径
-- main / preload / renderer / services 层的显式边界
-- 调试一个植入的运行时缺陷
+- Startup logs
+- Import and indexing logs
+- Visible QA failure path
+- Explicit boundaries between main, preload, renderer, and services layers
+- Debugging a seeded runtime defect
 
-## 对应课件
+## Related Lectures
 
-- [Lecture 07: 给代理划定清晰的任务边界](../../docs/lectures/lecture-07-why-agents-overreach-and-under-finish/index.md)
-- [Lecture 08: 用功能列表约束代理行为](../../docs/lectures/lecture-08-why-feature-lists-are-harness-primitives/index.md)
+- [Lecture 07: Why Agents Overreach and Under-Finish](../../docs/en/lectures/lecture-07-why-agents-overreach-and-under-finish/index.md)
+- [Lecture 08: Why Feature Lists Are Harness Primitives](../../docs/en/lectures/lecture-08-why-feature-lists-are-harness-primitives/index.md)

--- a/projects/project-05/README-CN.md
+++ b/projects/project-05/README-CN.md
@@ -1,0 +1,37 @@
+# Project 05: Evaluator Loops and Three-Role Upgrades
+
+测量角色分离（单角色 / 生成+评估 / 计划+生成+评估）如何改变实现质量。
+
+## 目录说明
+
+| 目录 | 含义 |
+|------|------|
+| `starter/` | **起点**——基于 P4 solution，新增多轮问答历史功能待实现。 |
+| `solution/single-role/` | **变体 A**——一个代理完成所有工作（规划 + 实现 + 自我评审）。基础质量。 |
+| `solution/gen-eval/` | **变体 B**——生成器 + 评估器模式。较高质量，有修订证据。 |
+| `solution/plan-gen-eval/` | **变体 C**——计划器 + 生成器 + 评估器。最高质量，有冲刺合约和评分标准。 |
+
+## 使用方法
+
+```sh
+# 三个变体各自独立运行
+cd solution/single-role && npm install  # 单角色模式
+cd solution/gen-eval && npm install     # 生成+评估模式
+cd solution/plan-gen-eval && npm install # 完整三角色模式
+
+# 对比三个变体的：
+# - 代码质量（evaluator-rubric.md 评分）
+# - 发现的缺陷数量
+# - 需要返工的程度
+```
+
+## 本项目涉及的功能
+
+- 多轮问答历史（对话式 UI）
+- 冲刺合约（sprint contract）
+- 评估器评分标准（evaluator rubric）调优
+
+## 对应课件
+
+- [Lecture 09: 阻止代理过早宣布胜利](../../docs/lectures/lecture-09-why-agents-declare-victory-too-early/index.md)
+- [Lecture 10: 只有全流程运行才算真正的验证](../../docs/lectures/lecture-10-why-end-to-end-testing-changes-results/index.md)

--- a/projects/project-05/README.md
+++ b/projects/project-05/README.md
@@ -1,37 +1,37 @@
 # Project 05: Evaluator Loops and Three-Role Upgrades
 
-测量角色分离（单角色 / 生成+评估 / 计划+生成+评估）如何改变实现质量。
+Measure how role separation (single role, generator plus evaluator, planner plus generator plus evaluator) changes implementation quality.
 
-## 目录说明
+## Directory Guide
 
-| 目录 | 含义 |
+| Directory | Meaning |
 |------|------|
-| `starter/` | **起点**——基于 P4 solution，新增多轮问答历史功能待实现。 |
-| `solution/single-role/` | **变体 A**——一个代理完成所有工作（规划 + 实现 + 自我评审）。基础质量。 |
-| `solution/gen-eval/` | **变体 B**——生成器 + 评估器模式。较高质量，有修订证据。 |
-| `solution/plan-gen-eval/` | **变体 C**——计划器 + 生成器 + 评估器。最高质量，有冲刺合约和评分标准。 |
+| `starter/` | **Starting point**: based on the P4 solution, with multi-turn QA history still to implement. |
+| `solution/single-role/` | **Variant A**: one agent does all work (planning, implementation, and self-review). Baseline quality. |
+| `solution/gen-eval/` | **Variant B**: generator plus evaluator pattern. Higher quality, with revision evidence. |
+| `solution/plan-gen-eval/` | **Variant C**: planner plus generator plus evaluator. Highest quality, with a sprint contract and scoring criteria. |
 
-## 使用方法
+## How to Use
 
 ```sh
-# 三个变体各自独立运行
-cd solution/single-role && npm install  # 单角色模式
-cd solution/gen-eval && npm install     # 生成+评估模式
-cd solution/plan-gen-eval && npm install # 完整三角色模式
+# Run each of the three variants independently
+cd solution/single-role && npm install  # single-role mode
+cd solution/gen-eval && npm install     # generator plus evaluator mode
+cd solution/plan-gen-eval && npm install # full three-role mode
 
-# 对比三个变体的：
-# - 代码质量（evaluator-rubric.md 评分）
-# - 发现的缺陷数量
-# - 需要返工的程度
+# Compare the three variants:
+# - Code quality (evaluator-rubric.md score)
+# - Number of defects found
+# - Amount of rework required
 ```
 
-## 本项目涉及的功能
+## Features Covered
 
-- 多轮问答历史（对话式 UI）
-- 冲刺合约（sprint contract）
-- 评估器评分标准（evaluator rubric）调优
+- Multi-turn QA history (conversational UI)
+- Sprint contract
+- Evaluator rubric tuning
 
-## 对应课件
+## Related Lectures
 
-- [Lecture 09: 阻止代理过早宣布胜利](../../docs/lectures/lecture-09-why-agents-declare-victory-too-early/index.md)
-- [Lecture 10: 只有全流程运行才算真正的验证](../../docs/lectures/lecture-10-why-end-to-end-testing-changes-results/index.md)
+- [Lecture 09: Why Agents Declare Victory Too Early](../../docs/en/lectures/lecture-09-why-agents-declare-victory-too-early/index.md)
+- [Lecture 10: Why End-to-End Testing Changes Results](../../docs/en/lectures/lecture-10-why-end-to-end-testing-changes-results/index.md)

--- a/projects/project-06/README-CN.md
+++ b/projects/project-06/README-CN.md
@@ -1,0 +1,43 @@
+# Project 06: Runtime Observability and Debugging (Capstone)
+
+课程毕业项目：构建并基准测试完整的 harness，执行清理循环验证质量可维护性。
+
+## 目录说明
+
+| 目录 | 含义 |
+|------|------|
+| `starter/` | **起点**——完整的产品代码，但 harness 被刻意削弱（只有基础 AGENTS.md，没有 feature_list.json、session-handoff、clean-state-checklist）。 |
+| `solution/` | **参考实现**——最大 harness：所有产物文件齐全，质量文档评分高，包含基准测试脚本和清理扫描器。 |
+
+## 使用方法
+
+```sh
+cd starter
+npm install
+# 用弱 harness 跑基准测试套件，记录结果
+
+cd ../solution
+npm install
+# 用完整 harness 跑同样的基准测试
+# 执行清理循环
+# 对比 quality-document.md 中的评分变化
+
+# 运行基准测试
+./scripts/benchmark.sh
+
+# 运行清理扫描
+./scripts/cleanup-scanner.sh
+```
+
+## 本项目涉及的功能
+
+- 导入文档
+- 构建或刷新索引
+- 带引用的问答
+- 运行时反馈
+- 可读的、可重启的仓库状态
+
+## 对应课件
+
+- [Lecture 11: 让代理的运行时可观测](../../docs/lectures/lecture-11-why-observability-belongs-inside-the-harness/index.md)
+- [Lecture 12: 每次会话都要留下干净的状态](../../docs/lectures/lecture-12-why-every-session-must-leave-a-clean-state/index.md)

--- a/projects/project-06/README.md
+++ b/projects/project-06/README.md
@@ -1,43 +1,43 @@
 # Project 06: Runtime Observability and Debugging (Capstone)
 
-课程毕业项目：构建并基准测试完整的 harness，执行清理循环验证质量可维护性。
+Capstone project: build and benchmark a complete harness, then run cleanup loops to verify quality and maintainability.
 
-## 目录说明
+## Directory Guide
 
-| 目录 | 含义 |
+| Directory | Meaning |
 |------|------|
-| `starter/` | **起点**——完整的产品代码，但 harness 被刻意削弱（只有基础 AGENTS.md，没有 feature_list.json、session-handoff、clean-state-checklist）。 |
-| `solution/` | **参考实现**——最大 harness：所有产物文件齐全，质量文档评分高，包含基准测试脚本和清理扫描器。 |
+| `starter/` | **Starting point**: complete product code, but the harness is intentionally weakened (only basic AGENTS.md, with no feature_list.json, session handoff, or clean-state checklist). |
+| `solution/` | **Reference implementation**: maximum harness, with all artifact files present, high quality-document scores, benchmark scripts, and cleanup scanners. |
 
-## 使用方法
+## How to Use
 
 ```sh
 cd starter
 npm install
-# 用弱 harness 跑基准测试套件，记录结果
+# Run the benchmark suite with the weak harness and record the results
 
 cd ../solution
 npm install
-# 用完整 harness 跑同样的基准测试
-# 执行清理循环
-# 对比 quality-document.md 中的评分变化
+# Run the same benchmark with the complete harness
+# Execute cleanup loops
+# Compare score changes in quality-document.md
 
-# 运行基准测试
+# Run benchmark tests
 ./scripts/benchmark.sh
 
-# 运行清理扫描
+# Run cleanup scan
 ./scripts/cleanup-scanner.sh
 ```
 
-## 本项目涉及的功能
+## Features Covered
 
-- 导入文档
-- 构建或刷新索引
-- 带引用的问答
-- 运行时反馈
-- 可读的、可重启的仓库状态
+- Import documents
+- Build or refresh the index
+- Answer questions with citations
+- Runtime feedback
+- Readable, restartable repository state
 
-## 对应课件
+## Related Lectures
 
-- [Lecture 11: 让代理的运行时可观测](../../docs/lectures/lecture-11-why-observability-belongs-inside-the-harness/index.md)
-- [Lecture 12: 每次会话都要留下干净的状态](../../docs/lectures/lecture-12-why-every-session-must-leave-a-clean-state/index.md)
+- [Lecture 11: Why Observability Belongs Inside the Harness](../../docs/en/lectures/lecture-11-why-observability-belongs-inside-the-harness/index.md)
+- [Lecture 12: Why Every Session Must Leave a Clean State](../../docs/en/lectures/lecture-12-why-every-session-must-leave-a-clean-state/index.md)


### PR DESCRIPTION
- Added Chinese README-CN.md files for projects 01-06.
- Updated the default project README.md files to English.
- Pointed related lecture links to the English documentation tree under docs/en/lectures.
- Preserved the same project structure, usage guidance, and feature coverage across both language
  versions.