### PR TITLE
docs: add Turkish locale to Resource Library and repository structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ npm run test:watch       # Vitest watch mode
 ## Repository Structure
 
 - `docs/` — VitePress documentation site (lectures, projects, resources)
-- `docs/.vitepress/config.mts` — Nav/sidebar config for both EN and ZH locales
+- `docs/.vitepress/config.mts` — Nav/sidebar config for all 13 locales (en, zh, zh-TW, ja, ko, es, fr, ru, de, ar, vi, uz, tr)
 - `docs/lectures/` — 12 lectures, each with `index.md` + `code/` examples
 - `docs/projects/` — 6 project descriptions
 - `docs/<lang>/resources/` — localized templates, references, OpenAI advanced pack

--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ Each phase takes about a week if you're going part-time. If you want to go faste
 - [العربية](https://walkinglabs.github.io/learn-harness-engineering/ar/resources/) — قوالب، قوائم تحقق ومراجع
 - [Tiếng Việt](https://walkinglabs.github.io/learn-harness-engineering/vi/resources/) — mẫu, danh sách kiểm tra và tài liệu tham khảo
 - [Oʻzbekcha](https://walkinglabs.github.io/learn-harness-engineering/uz/resources/) — andozalar, tekshiruv roʻyxatlari va maʼlumotnomalar
+- [Türkçe](https://walkinglabs.github.io/learn-harness-engineering/tr/resources/) — şablonlar, kontrol listeleri ve başvurular
 
 ---
 
@@ -530,16 +531,13 @@ learn-harness-engineering/
 ├── docs/                          # VitePress documentation site
 │   ├── lectures/                  # 12 lectures (index.md + code/ examples)
 │   │   ├── lecture-01-*/
-│   │   ├── lecture-02-*/
 │   │   └── ... (12 total)
 │   ├── projects/                  # 6 project descriptions
 │   │   ├── project-01-*/
 │   │   └── ... (6 total)
-│   └── resources/                 # Multilingual templates & references
-│       ├── en/                    # English templates, checklists, guides
-│       ├── zh/                    # Chinese templates, checklists, guides
-│       ├── ru/                    # Russian templates, checklists, guides
-│       └── vi/                    # Vietnamese templates, checklists, guides
+│   └── resources/                 # Multilingual templates & references (13 languages)
+│       ├── en/
+│       └── ... (13 total)
 ├── projects/
 │   ├── shared/                    # Shared Electron + TypeScript + React foundation
 │   └── project-NN/                # Per-project starter/ and solution/ directories


### PR DESCRIPTION
The Turkish locale (`docs/tr/`) already exists in the repository but was missing from two places in the documentation:

- **Resource Library** section in README.md: Türkçe link was not listed alongside the other 12 languages
- **Repository Structure** section in README.md: standardized the format — lectures, projects, and resources sections now all follow the same pattern (`first-item-*/` + `... (N total)`)
- **CLAUDE.md**: updated VitePress config note from "EN and ZH locales" to all 13 locales
