### PR TITLE
fix: correct Turkish resource description from başvurular to referanslar

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Each phase takes about a week if you're going part-time. If you want to go faste
 - [العربية](https://walkinglabs.github.io/learn-harness-engineering/ar/resources/) — قوالب، قوائم تحقق ومراجع
 - [Tiếng Việt](https://walkinglabs.github.io/learn-harness-engineering/vi/resources/) — mẫu, danh sách kiểm tra và tài liệu tham khảo
 - [Oʻzbekcha](https://walkinglabs.github.io/learn-harness-engineering/uz/resources/) — andozalar, tekshiruv roʻyxatlari va maʼlumotnomalar
-- [Türkçe](https://walkinglabs.github.io/learn-harness-engineering/tr/resources/) — şablonlar, kontrol listeleri ve başvurular
+- [Türkçe](https://walkinglabs.github.io/learn-harness-engineering/tr/resources/) — şablonlar, kontrol listeleri ve referanslar
 
 ---
 


### PR DESCRIPTION
The Turkish resource library description in README.md used "başvurular" (meaning "references/applications" in a general sense) to translate "method references". Updated to "referanslar" which is the term used consistently in the Turkish documentation (`docs/tr/resources/index.md`).