### PR TITLE
Update HumanLayer link for harness engineering

### DIFF
--- a/docs/en/lectures/lecture-02-what-a-harness-actually-is/index.md
+++ b/docs/en/lectures/lecture-02-what-a-harness-actually-is/index.md
@@ -96,7 +96,7 @@ Four iterations, the model did not change at all, and success rate went from 20%
 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 - [Thoughtworks: Harness Engineering on Technology Radar](https://www.thoughtworks.com/radar)
 


### PR DESCRIPTION
This PR fixes a broken link to the Humanlayer blog. The blog URLs were migrated from /articles to /blogs, and this update corrects the affected link.

Note: This change only updates the English version. If there's a more efficient way to apply the fix across all locales instead of updating each directory individually, please let me know. Otherwise, I'll submit a follow-up PR to update the remaining language versions.