### PR TITLE
Add Portuguese (BR) localization for projects and skills documentation

### DIFF
--- a/docs-readme/pt-BR/README.md
+++ b/docs-readme/pt-BR/README.md
@@ -26,7 +26,7 @@
   <img src="https://img.shields.io/badge/Licença-MIT-lightgrey?style=flat-square" alt="Licença MIT">
 </p>
 
-> **Ícone de globo** Este curso está disponível em **14 idiomas**: Inglês, 简体中文, 繁體中文, 日本語, 한국어, Español, Français, Русский, Deutsch, العربية, Tiếng Việt, Oʻzbekcha, Türkçe e Português (BR). Escolha seu idioma nos emblemas acima.
+> 🌍 Este curso está disponível em **14 idiomas**: Inglês, 简体中文, 繁體中文, 日本語, 한국어, Español, Français, Русский, Deutsch, العربية, Tiếng Việt, Oʻzbekcha, Türkçe e Português (BR). Escolha seu idioma nos emblemas acima.
 
 Aprenda Engenharia de Harness é um curso dedicado à engenharia de agentes de codificação de IA. Estudamos profundamente e sintetizamos as teorias e práticas mais avançadas de Engenharia de Harness na indústria. Nossas referências principais incluem:
 
@@ -41,14 +41,14 @@ Aprenda Engenharia de Harness é um curso dedicado à engenharia de agentes de c
 
 ## Índice
 
-- [✨ Prévia Visual](#-visual-preview)
-- [O que Realmente Significa Engenharia de Harness](#what-harness-engineering-actually-means)
-- [Início Rápido: Melhore Seu Agente Hoje](#quick-start-improve-your-agent-today)
-- [Projeto Final: Um Aplicativo Real](#capstone-project-a-real-app)
-- [Trilha de Aprendizagem](#learning-path)
-- [Ementa](#syllabus)
+- [✨ Prévia Visual](#-prévia-visual)
+- [O que Realmente Significa Engenharia de Harness](#o-que-realmente-significa-engenharia-de-harness)
+- [Início Rápido: Melhore Seu Agente Hoje](#início-rápido-melhore-seu-agente-hoje)
+- [Projeto Final: Um Aplicativo Real](#projeto-final-um-aplicativo-real)
+- [Trilha de Aprendizagem](#trilha-de-aprendizagem)
+- [Ementa](#ementa)
 - [Skills](#skills)
-- [Outros Cursos](#other-courses)
+- [Outros Cursos](#outros-cursos)
 
 ---
 
@@ -233,6 +233,290 @@ Pegue os modelos iniciais da [Biblioteca de Recursos](https://walkinglabs.github
 
 Todos os seis projetos do curso giram em torno do mesmo produto: **um aplicativo de desktop de base de conhecimento pessoal baseado em Electron**.
 
+```text
+    ┌──────────────────────────────────────────────────────┐
+    │       App de Desktop de Base de Conhecimento         │
+    │                                                      │
+    │  ┌──────────────┐  ┌──────────────────────────────┐  │
+    │  │ Lista de Doc │  │       Painel de Q&A          │  │
+    │  │              │  │                              │  │
+    │  │ doc-001.md   │  │  P: O que é eng. de harness? │  │
+    │  │ doc-002.md   │  │  R: O ambiente construído    │  │
+    │  │ doc-003.md   │  │     ao redor de um modelo... │  │
+    │  │ ...          │  │     [citação: doc-002.md]    │  │
+    │  └──────────────┘  └──────────────────────────────┘  │
+    │                                                      │
+    │  ┌─────────────────────────────────────────────────┐ │
+    │  │ Barra Status: 42 docs | 38 indexados | sinc 3m  │ │
+    │  └─────────────────────────────────────────────────┘ │
+    └──────────────────────────────────────────────────────┘
+
+    Recursos principais:
+    ├── Importar documentos locais
+    ├── Gerenciar uma biblioteca de documentos
+    ├── Processar e indexar documentos
+    ├── Executar Q&A com IA sobre o conteúdo importado
+    └── Retornar respostas fundamentadas com citações
+```
+
+Este projeto foi escolhido porque combina um forte valor prático, complexidade de produto do mundo real suficiente e um bom cenário para observar as melhorias de harness antes e depois.
+
+O ponto de partida/solução de cada projeto do curso é uma cópia completa deste aplicativo Electron nesse estágio evolutivo. O ponto de partida do P(N+1) é derivado da solução do P(N) — o aplicativo evolui conforme suas habilidades de harness crescem.
+
+---
+
+## Trilha de Aprendizado
+
+O curso foi projetado para ser realizado em ordem. Cada fase se baseia na anterior.
+
+```text
+    Fase 1: ENTENDA O PROBLEMA            Fase 2: ESTRUTURE O REPOSITÓRIO
+    ==========================           ===============================
+
+    L01  Modelos poderosos ≠ execução    L03  Repositório como fonte
+         confiável                             única da verdade
+    L02  O que realmente significa
+         harness                          L04  Divida as instruções em
+                                               vários arquivos, não em
+         |                                     um único arquivo gigante
+         v
+    P01  Comparação entre                     |
+         apenas prompt vs.                    v
+         abordagem orientada por regras  P02  Workspace legível por agentes
+
+
+    Fase 3: CONECTE AS SESSÕES           Fase 4: FEEDBACK E ESCOPO
+    ==========================           =========================
+
+    L05  Mantenha o contexto ativo       L07  Defina limites claros
+         entre sessões                        para as tarefas
+
+    L06  Inicialize antes de cada        L08  Listas de funcionalidades
+         sessão do agente                     como primitivas de harness
+
+         |                                    |
+         v                                    v
+    P03  Continuidade entre múltiplas    P04  Feedback em tempo de
+         sessões                              execução para corrigir
+                                               o comportamento do agente
+
+
+    Fase 5: VERIFICAÇÃO                  Fase 6: JUNTE TUDO
+    ====================                 ==================
+
+    L09  Impedir que agentes             L11  Tornar o comportamento
+         declarem vitória cedo                do agente observável
+         demais
+                                         L12  Encerramento organizado ao
+    L10  Executar o pipeline completo =       final de cada sessão
+         verificação real
+                                              |
+         |                                    v
+         v                               P06  Construir um harness
+    P05  O agente verifica o próprio          completo (projeto final)
+         trabalho
+```
+
+Cada fase leva cerca de uma semana se você estiver estudando em meio período. Se quiser avançar mais rápido, as fases 1–3 podem ser concluídas em um fim de semana prolongado.
+
+---
+
+## Ementa
+
+### Aulas — 12 unidades conceituais, cada uma respondendo a uma pergunta central
+
+*Leia o texto completo de cada aula no [Site de Documentação](https://walkinglabs.github.io/learn-harness-engineering/).*
+
+| Sessão | Pergunta | Ideia Central |
+|---------|----------|-----------|
+| [L01](../../docs/pt-BR/lectures/lecture-01-why-capable-agents-still-fail/index.md) | Por que modelos fortes ainda falham em tarefas reais? | A lacuna de capacidade entre benchmarks e engenharia real |
+| [L02](../../docs/pt-BR/lectures/lecture-02-what-a-harness-actually-is/index.md) | O que "harness" realmente significa? | Cinco subsistemas: instruções, estado, verificação, escopo, ciclo de vida |
+| [L03](../../docs/pt-BR/lectures/lecture-03-why-the-repository-must-become-the-system-of-record/index.md) | Por que o repositório deve ser a única fonte de verdade? | Se o agente não consegue ver, não existe |
+| [L04](../../docs/pt-BR/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md) | Por que um único arquivo de instrução gigante falha? | Divulgação progressiva: forneça um mapa, não uma enciclopédia |
+| [L05](../../docs/pt-BR/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md) | Por que tarefas de longa duração perdem a continuidade? | Persista o progresso no disco; recomece de onde parou |
+| [L06](../../docs/pt-BR/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md) | Por que a inicialização precisa de sua própria fase? | Verifique se o ambiente está saudável antes do agente começar o trabalho |
+| [L07](../../docs/pt-BR/lectures/lecture-07-why-agents-overreach-and-under-finish/index.md) | Por que os agentes se excedem e não terminam o que começaram? | Um recurso por vez; definição explícita de concluído |
+| [L08](../../docs/pt-BR/lectures/lecture-08-why-feature-lists-are-harness-primitives/index.md) | Por que as listas de recursos são primitivas de harness? | Limites de escopo legíveis por máquina que o agente não pode ignorar |
+| [L09](../../docs/pt-BR/lectures/lecture-09-why-agents-declare-victory-too-early/index.md) | Por que os agentes declaram vitória cedo demais? | Lacunas de verificação: confiança ≠ correção |
+| [L10](../../docs/pt-BR/lectures/lecture-10-why-end-to-end-testing-changes-results/index.md) | Por que o teste de ponta a ponta muda os resultados? | Apenas uma execução de pipeline completa conta como verificação real |
+| [L11](../../docs/pt-BR/lectures/lecture-11-why-observability-belongs-inside-the-harness/index.md) | Por que a observabilidade pertence ao harness? | Se você não pode ver o que o agente fez, não pode consertar o que ele quebrou |
+| [L12](../../docs/pt-BR/lectures/lecture-12-why-every-session-must-leave-a-clean-state/index.md) | Por que cada sessão deve deixar um estado limpo? | O sucesso da próxima sessão depende da limpeza desta sessão |
+
+### Projetos — 6 projetos práticos aplicando os métodos das aulas ao mesmo aplicativo Electron
+
+| Projeto | O Que Você Faz | Mecanismo de Harness |
+|---------|------------|-------------------|
+| [P01](../../docs/pt-BR/projects/project-01-baseline-vs-minimal-harness/index.md) | Execute a mesma tarefa duas vezes: apenas prompt vs. regras primeiro | Harness mínimo: AGENTS.md + init.sh + feature_list.json |
+| [P02](../../docs/pt-BR/projects/project-02-agent-readable-workspace/index.md) | Reestruture o repositório para que o agente possa lê-lo | Espaço de trabalho legível pelo agente + arquivos de estado persistentes |
+| [P03](../../docs/pt-BR/projects/project-03-multi-session-continuity/index.md) | Faça o agente recomeçar de onde parou | Log de progresso + entrega de sessão + continuidade multi-sessão |
+| [P04](../../docs/pt-BR/projects/project-04-incremental-indexing/index.md) | Impeça o agente de fazer demais ou de menos | Feedback de tempo de execução + controle de escopo + indexação incremental |
+| [P05](../../docs/pt-BR/projects/project-05-grounded-qa-verification/index.md) | Faça o agente verificar seu próprio trabalho | Autoverificação + Q&A fundamentado + conclusão baseada em evidências |
+| [P06](../../docs/pt-BR/projects/project-06-runtime-observability-and-debugging/index.md) | Construa um harness completo do zero (projeto final) | Harness completo: todos os mecanismos + observabilidade + estudo de ablação |
+
+```text
+    EVOLUÇÃO DO PROJETO
+    ===================
+
+    P01  Apenas prompt vs. regras primeiro    Você vê o problema
+     |
+     v
+    P02  Espaço de trabalho legível pelo agente Você reestrutura o repositório
+     |
+     v
+    P03  Continuidade multi-sessão             Você conecta as sessões
+     |
+     v
+    P04  Feedback e escopo em tempo real       Você adiciona loops de feedback
+     |
+     v
+    P05  Autoverificação                       Você faz o agente se verificar
+     |
+     v
+    P06  Harness completo (projeto final)      Você constrói o sistema completo
+
+    A solução de cada projeto torna-se o ponto de partida do próximo projeto.
+    O aplicativo evolui. Suas habilidades de harness crescem com ele.
+```
+
+### Biblioteca de Recursos
+
+- [English](https://walkinglabs.github.io/learn-harness-engineering/en/resources/) — modelos, checklists e referências de métodos
+- [简体中文](https://walkinglabs.github.io/learn-harness-engineering/zh/resources/) — 中文模板、清单和方法参考
+- [繁體中文](https://walkinglabs.github.io/learn-harness-engineering/zh-TW/resources/) — 繁體中文範本、清單和方法參考
+- [日本語](https://walkinglabs.github.io/learn-harness-engineering/ja/resources/) — テンプレート、チェックリスト、方法リファレンス
+- [한국어](https://walkinglabs.github.io/learn-harness-engineering/ko/resources/) — 템플릿, 체크리스트, 방법 참고 자료
+- [Español](https://walkinglabs.github.io/learn-harness-engineering/es/resources/) — plantillas, listas de verificación y referencias
+- [Français](https://walkinglabs.github.io/learn-harness-engineering/fr/resources/) — modèles, listes de contrôle et références
+- [Русский](https://walkinglabs.github.io/learn-harness-engineering/ru/resources/) — шаблоны, чек-листы и справочники
+- [Deutsch](https://walkinglabs.github.io/learn-harness-engineering/de/resources/) — Vorlagen, Checklisten und Referenzen
+- [العربية](https://walkinglabs.github.io/learn-harness-engineering/ar/resources/) — قوالب، قوائم تحقق ومراجع
+- [Tiếng Việt](https://walkinglabs.github.io/learn-harness-engineering/vi/resources/) — mẫu, danh sách kiểm tra và tài liệu tham khảo
+- [Oʻzbekcha](https://walkinglabs.github.io/learn-harness-engineering/uz/resources/) — andozalar, tekshiruv roʻyxatlari va maʼlumotnomalar
+- [Türkçe](https://walkinglabs.github.io/learn-harness-engineering/tr/resources/) — şablonlar, kontrol listeleri ve referanslar
+- [Português (BR)](https://walkinglabs.github.io/learn-harness-engineering/pt-BR/resources/) — modelos, listas de verificação e referências de métodos
+
+---
+
+## O Ciclo de Vida de uma Sessão de Agente
+
+Uma das ideias centrais deste curso: **a sessão do agente deve seguir um ciclo de vida estruturado, e não funcionar sem regras ou organização.** Veja como isso funciona:
+
+```text
+    CICLO DE VIDA DE UMA SESSÃO DE AGENTE
+    =====================================
+
+    ┌──────────────────────────────────────────────────────────────────┐
+    │  INÍCIO                                                         │
+    │                                                                  │
+    │  1. O agente lê AGENTS.md / CLAUDE.md                            │
+    │  2. O agente executa init.sh (instalação, verificação,           │
+    │     checagem de integridade)                                     │
+    │  3. O agente lê claude-progress.md (o que aconteceu na última    │
+    │     sessão)                                                      │
+    │  4. O agente lê feature_list.json (o que foi concluído e o que   │
+    │     vem a seguir)                                                │
+    │  5. O agente verifica o git log (alterações recentes)            │
+    │                                                                  │
+    │  SELECIONAR                                                      │
+    │                                                                  │
+    │  6. O agente escolhe exatamente UMA funcionalidade não concluída │
+    │  7. O agente trabalha apenas nessa funcionalidade               │
+    │                                                                  │
+    │  EXECUTAR                                                        │
+    │                                                                  │
+    │  8. O agente implementa a funcionalidade                         │
+    │  9. O agente executa as verificações (testes, lint,              │
+    │     verificação de tipos)                                        │
+    │  10. Se a verificação falhar: corrigir e executar novamente      │
+    │  11. Se a verificação passar: registrar evidências               │
+    │                                                                  │
+    │  ENCERRAMENTO                                                    │
+    │                                                                  │
+    │  12. O agente atualiza claude-progress.md                        │
+    │  13. O agente atualiza feature_list.json                         │
+    │  14. O agente registra o que ainda está quebrado ou não foi      │
+    │      verificado                                                  │
+    │  15. O agente faz commit (somente quando for seguro retomar)     │
+    │  16. O agente deixa um caminho de reinício limpo para a próxima  │
+    │      sessão                                                      │
+    │                                                                  │
+    └──────────────────────────────────────────────────────────────────┘
+```
+
+    O harness governa cada transição desse ciclo de vida.
+    O modelo decide qual código escrever em cada etapa.
+    Sem o harness, a etapa 9 se torna: "o agente diz que parece estar tudo certo."
+    Com o harness, a etapa 9 se torna: "os testes passaram, o lint está limpo e a verificação de tipos foi concluída com sucesso."
+
+---
+
+## Para Quem Este Curso É Indicado
+
+Este curso é voltado para:
+
+- Engenheiros que já utilizam agentes de programação e desejam maior estabilidade e qualidade
+- Pesquisadores ou criadores que desejam uma compreensão sistemática sobre design de harness
+- Tech leads que precisam entender como o design do ambiente afeta o desempenho dos agentes
+
+Este curso não é indicado para:
+
+- Pessoas que procuram uma introdução à IA sem código
+- Pessoas que se preocupam apenas com prompts e não pretendem construir implementações reais
+- Alunos que não estão dispostos a permitir que agentes trabalhem dentro de repositórios reais
+
+---
+
+## Requisitos
+
+Este é um curso em que você realmente executará agentes de programação.
+
+Você precisará de pelo menos uma destas ferramentas:
+
+- Claude Code
+- Codex
+- Outro agente de programação para IDE ou CLI que ofereça suporte à edição de arquivos, execução de comandos e tarefas de múltiplas etapas
+
+O curso pressupõe que você seja capaz de:
+
+- Abrir um repositório local
+- Permitir que o agente edite arquivos
+- Permitir que o agente execute comandos
+- Inspecionar saídas e executar tarefas novamente
+
+Se você não tiver uma ferramenta desse tipo, ainda poderá ler o conteúdo do curso, mas não conseguirá concluir os projetos da forma como foram planejados.
+
+---
+
+## Visualização Local
+
+Este repositório utiliza o VitePress como visualizador de documentação.
+
+```sh
+npm install
+npm run docs:dev        # Servidor de desenvolvimento com recarregamento automático
+npm run docs:build      # Build de produção
+npm run docs:preview    # Visualizar o site gerado
+```
+
+Em seguida, abra no navegador a URL local exibida pelo VitePress.
+
+---
+
+## Pré-requisitos
+
+Obrigatórios:
+
+- Familiaridade com terminal, Git e ambientes de desenvolvimento locais
+- Capacidade de ler e escrever código em pelo menos uma stack de aplicações comum
+- Experiência básica com depuração de software (leitura de logs, testes e comportamento em tempo de execução)
+- Tempo suficiente para se dedicar a um curso com foco em implementação prática
+
+Úteis, mas não obrigatórios:
+
+- Experiência com Electron, aplicações desktop ou ferramentas local-first
+- Conhecimento em testes, logging ou arquitetura de software
+- Experiência prévia com Codex, Claude Code ou agentes de programação semelhantes
+
 ---
 
 ## Referências Principais
@@ -306,6 +590,12 @@ Nossa equipe também criou outros cursos! Confira-os:
 [![Modern LLM Notebook](https://img.shields.io/badge/MODERN_LLM_NOTEBOOK-0052cc?style=for-the-badge)](https://github.com/walkinglabs/modern-llm-notebook)
 
 **Modern LLM Notebook**: Um curso prático para construir LLMs modernos do zero em PyTorch, com 23 Jupyter Notebooks executáveis cobrindo tokenizadores, atenção, MoE, RLHF, inferência, avaliação e destilação.
+
+---
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://www.star-history.com/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
 
 ---
 

--- a/projects/project-01/README-PT-BR.md
+++ b/projects/project-01/README-PT-BR.md
@@ -1,0 +1,58 @@
+# Projeto 01: Baseline vs. Harness Mínimo
+
+Compare como um harness fraco (apenas prompt) e um harness explícito (arquivos de regras mais mecanismos de verificação) afetam a taxa de conclusão de tarefas de agentes de programação com IA.
+
+## Guia de Diretórios
+
+| Diretório | Significado |
+|------|------|
+| `starter/` | **Ponto de partida**: apenas um `task-prompt.md` vago, sem `AGENTS.md` e sem `feature_list.json`. Esta é a versão de "harness fraco" que você entrega ao agente. |
+| `solution/` | **Implementação de referência**: o mesmo código da aplicação, mas com arquivos completos de harness (`AGENTS.md`, `feature_list.json`, `init.sh`, `claude-progress.md`). Esta é a versão de "harness explícito". |
+
+## Como Usar
+
+```sh
+# 1. Execute a tarefa do agente uma vez com starter (harness fraco)
+cd starter
+npm install
+# Forneça o conteúdo de task-prompt.md como prompt para Claude Code / Codex
+# Peça ao agente para concluir: inicialização da janela, lista de documentos, painel de QA, diretório de dados
+# Não forneça os arquivos da solução ao agente durante esta execução.
+
+# 2. Execute a mesma tarefa com solution (harness explícito)
+cd ../solution
+npm install
+# Peça ao agente para ler AGENTS.md, init.sh, feature_list.json e claude-progress.md
+# antes de alterar o código. O código do produto já deve satisfazer as mesmas quatro funcionalidades.
+
+# 3. Compare os dois resultados
+# - A tarefa foi concluída?
+# - Quantas tentativas adicionais foram necessárias?
+# - O agente afirmou "concluído" cedo demais?
+```
+
+## Contrato Exato da Tarefa
+
+O prompt inicial é intencionalmente vago (`starter/task-prompt.md` contém apenas
+"Construa uma aplicação Electron que possa exibir documentos e responder perguntas."). Use o harness da solução para tornar essa solicitação vaga concreta:
+
+| Funcionalidade | Evidência do Starter para inspecionar | Evidência da Solution para comparar |
+|------|------|------|
+| Inicialização da janela | `src/main/main.ts`, `src/preload/preload.ts` | Item `window-launch` do `feature_list.json` |
+| Painel de lista de documentos | `src/renderer/components/DocumentList.tsx` | Item `document-list` do `feature_list.json` |
+| Painel de perguntas | `src/renderer/components/QuestionPanel.tsx` | Item `question-panel` do `feature_list.json` |
+| Diretório de dados | `src/services/persistence-service.ts` | Item `data-directory` do `feature_list.json` |
+
+Este projeto é um experimento, não uma tarefa comum de "preencher o starter até que ele seja igual à solução". O resultado de aprendizado é a diferença medida entre uma execução baseada apenas em prompt e uma execução que começa com regras explícitas do repositório e artefatos de verificação.
+
+## Funcionalidades Cobertas
+
+- A janela do Electron inicia com sucesso
+- A interface exibe a área da lista de documentos
+- A interface exibe o painel de QA
+- A aplicação cria e utiliza um diretório de dados local
+
+## Aulas Relacionadas
+
+- [Aula 01: Por Que Agentes Capazes Ainda Falham](../../docs/pt-BR/lectures/lecture-01-why-capable-agents-still-fail/index.md)
+- [Aula 02: O Que É Um Harness na Prática](../../docs/pt-BR/lectures/lecture-02-what-a-harness-actually-is/index.md)

--- a/projects/project-02/README-PT-BR.md
+++ b/projects/project-02/README-PT-BR.md
@@ -1,0 +1,53 @@
+# Projeto 02: Workspace Legível por Agentes
+
+Demonstre como a legibilidade do repositório e artefatos explícitos de continuidade reduzem a perda de contexto durante o desenvolvimento em múltiplas sessões.
+
+## Guia de Diretórios
+
+| Diretório | Significado |
+|------|------|
+| `starter/` | **Ponto de partida**: baseado na solução do P1, com importação de documentos, visualização de detalhes e persistência ainda pendentes de implementação. O harness é fraco: o `AGENTS.md` é mínimo e não existe um handoff de sessão. |
+| `solution/` | **Implementação de referência**: todos os novos recursos estão implementados, com documentação completa do workspace (`ARCHITECTURE.md`, `PRODUCT.md`, `session-handoff.md`). |
+
+## Como Usar
+
+```sh
+# Requer pelo menos 2 sessões de agente para concluir
+cd starter
+npm install
+# Sessão A: implemente a importação de documentos e a visualização de detalhes
+# Sessão B: implemente a persistência (observe se o agente recupera rapidamente o contexto)
+
+cd ../solution
+npm install
+# Execute novamente com o harness completo e compare a velocidade de recuperação da sessão
+```
+
+## Contrato Exato da Tarefa
+
+Comece a partir de `starter/`. O starter já contém o shell do Projeto 01 e um
+harness mínimo. O trabalho é adicionar o recorte de produto do Projeto 02 e a
+documentação do workspace que permite que uma segunda sessão recupere o contexto rapidamente.
+
+| Funcionalidade / artefato | Estado no Starter | Evidência da Solution |
+|------|------|------|
+| Importação de documentos | O fluxo de importação está incompleto entre renderer, preload, IPC e `DocumentService` | `src/renderer/components/ImportPanel.tsx`, `src/main/ipc-handlers.ts`, `src/services/document-service.ts` |
+| Detalhes do documento | O painel de detalhes não carrega nem renderiza o conteúdo completo do arquivo via IPC | `src/renderer/components/DocumentDetail.tsx`, `IPC_CHANNELS.GET_DOCUMENT_CONTENT` |
+| Persistência básica | Documentos importados não são totalmente restaurados após reinicialização | `src/services/persistence-service.ts`, tratamento de `documents-meta.json` |
+| Estado legível pelo agente | Não existe arquivo final de handoff no starter | `session-handoff.md`, `docs/ARCHITECTURE.md` expandido, `docs/PRODUCT.md` expandido |
+
+Execute isso como um exercício de duas sessões. Encerre a Sessão A antes que as três
+funcionalidades do produto estejam completas e, em seguida, inicie a Sessão B usando
+apenas o estado atual do repositório. A principal comparação é o quanto mais rápido
+a Sessão B consegue retomar quando `session-handoff.md` e a documentação existem.
+
+## Funcionalidades Cobertas
+
+- Fluxo de importação de documentos (seletor de arquivos mais transferência via IPC)
+- Visualização de detalhes do documento (metadados mais exibição do conteúdo)
+- Persistência básica (documentos importados permanecem após reinicialização)
+
+## Aulas Relacionadas
+
+- [Aula 03: Por Que o Repositório Deve se Tornar a Fonte Oficial da Verdade](../../docs/pt-BR/lectures/lecture-03-why-the-repository-must-become-the-system-of-record/index.md)
+- [Aula 04: Por Que Um Único Arquivo Gigante de Instruções Falha](../../docs/pt-BR/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md)

--- a/projects/project-03/README-PT-BR.md
+++ b/projects/project-03/README-PT-BR.md
@@ -1,0 +1,53 @@
+# Projeto 03: Continuidade entre Múltiplas Sessões com Controle de Escopo
+
+Avalie se logs de progresso, handoff de sessão, controle explícito de escopo e
+gates de verificação melhoram a precisão da entrega durante reinicializações.
+
+## Guia de Diretórios
+
+| Diretório | Significado |
+|------|------|
+| `starter/` | **Ponto de partida**: baseado na solução do P2, com divisão de documentos em partes, extração de metadados, status de indexação e QA baseado em contexto ainda pendentes de implementação. Ele possui um `feature_list.json` inicial, mas não possui o harness completo de retomada (`init.sh`, `session-handoff.md`, `claude-progress.md`, checklist de estado limpo). |
+| `solution/` | **Implementação de referência**: todos os recursos estão implementados. O `AGENTS.md` inclui a estratégia de "uma funcionalidade por vez", e o repositório adiciona artefatos de reinicialização/continuidade (`init.sh`, `session-handoff.md`, `claude-progress.md`, `clean-state-checklist.md`). |
+
+## Como Usar
+
+```sh
+cd starter
+npm install
+# Execute pelo menos duas sessões de agente. Interrompa uma vez no meio da tarefa e depois retome a partir do estado do repositório.
+# Observe se o agente mantém o escopo e atualiza o feature_list.json.
+
+cd ../solution
+npm install
+# Inspecione os artefatos de continuidade concluídos e as evidências das funcionalidades.
+```
+
+## Contrato Exato da Tarefa
+
+O starter do Projeto 03 não é uma aplicação vazia. Ele é o Projeto 02 mais o trabalho
+de indexação e QA baseado em contexto ainda não concluído. Complete estes itens um por vez:
+
+| Funcionalidade / artefato | Estado no Starter | Evidência da Solution |
+|------|------|------|
+| Divisão de documentos em partes | `IndexingService` precisa criar chunks considerando parágrafos | `src/services/indexing-service.ts`, item `document-chunking` do `feature_list.json` |
+| Extração de metadados | Os metadados dos documentos estão incompletos para o trabalho de indexação | `src/services/document-service.ts`, `DocumentDetail.tsx`, item `metadata-extraction` |
+| Interface de status de indexação | Barra de status precisa exibir quantidade indexada / total de chunks / status por cores | `src/renderer/components/StatusBar.tsx`, `App.tsx`, item `indexing-status-ui` |
+| QA baseado em contexto | O QA deve citar chunks recuperados com trechos e nível de confiança | `src/services/qa-service.ts`, `QuestionPanel.tsx`, item `grounded-qa` |
+| Harness de continuidade | O Starter não possui os artefatos finais de retomada/handoff | `init.sh`, `session-handoff.md`, `claude-progress.md`, `clean-state-checklist.md` |
+
+Não trate isso como "adicionar qualquer funcionalidade de múltiplas sessões". O recorte
+de produto esperado é indexação mais QA baseado em citações, e o recorte de harness
+esperado é o rastreamento de progresso que permite retomada.
+
+## Funcionalidades Cobertas
+
+- Divisão de documentos em partes (baseada em parágrafos, cerca de 500 caracteres)
+- Extração de metadados (contagem de palavras, contagem de linhas, contagem de parágrafos)
+- Status da indexação exibido na interface
+- Fluxo básico de QA com citações de fontes
+
+## Aulas Relacionadas
+
+- [Aula 05: Por Que Tarefas de Longa Duração Perdem Continuidade](../../docs/pt-BR/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md)
+- [Aula 06: Por Que a Inicialização Precisa Ter Sua Própria Fase](../../docs/pt-BR/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md)

--- a/projects/project-04/README-PT-BR.md
+++ b/projects/project-04/README-PT-BR.md
@@ -1,0 +1,55 @@
+# Projeto 04: Feedback em Tempo de Execução e Controle Estrutural
+
+Introduza observabilidade em tempo de execução e verificações de limites estruturais enquanto depura um defeito de execução pré-configurado.
+
+## Guia de Diretórios
+
+| Diretório | Significado |
+|------|------|
+| `starter/` | **Ponto de partida**: baseado na solução do P3, com recursos de logging e limites estruturais ainda pendentes de implementação. O `IndexingService` contém um bug oculto pré-configurado: arquivos com mais de 1000 caracteres podem gerar chunks vazios. Não existe script de verificação de arquitetura nem checklist final de estado limpo. |
+| `solution/` | **Implementação de referência**: módulo de logging estruturado, script de verificação de limites de arquitetura e o bug pré-configurado corrigido. |
+
+## Como Usar
+
+```sh
+cd starter
+npm install
+# 1. Observe se o agente consegue localizar o bug através dos logs
+# 2. Importe um arquivo grande e verifique se o comportamento de divisão em chunks está incorreto
+
+cd ../solution
+npm install
+# Compare como logs estruturados aceleram o diagnóstico
+```
+
+## Contrato Exato da Tarefa
+
+O Projeto 04 é um exercício de depuração e criação de proteções. O starter já contém
+o recorte de produto do Projeto 03, mas o ambiente de execução é mais difícil de
+inspecionar e o defeito de divisão em chunks pré-configurado deve ser corrigido somente
+depois que o agente conseguir visualizar evidências suficientes.
+
+| Funcionalidade / artefato | Estado no Starter | Evidência da Solution |
+|------|------|------|
+| Logging estruturado | Não existe um serviço de logger compartilhado | `src/services/logger.ts`, chamadas de logging em `main.ts`, `ipc-handlers.ts` e serviços |
+| Diagnósticos de importação / indexação | Falhas são difíceis de rastrear a partir da saída de execução | Entradas de log ao redor da importação, início/conclusão da indexação e caminhos de falha do QA |
+| Limites de arquitetura | Não existe script que verifique desvios entre limites de renderer/main/service | `scripts/check-architecture.sh`, `docs/ARCHITECTURE.md`, regras de limites no AGENTS |
+| Bug pré-configurado de divisão em chunks | Arquivos grandes podem gerar saída de chunks inválida/vazia | Lógica de parágrafos/chunks corrigida em `src/services/indexing-service.ts` |
+| Handoff limpo | O Starter não possui checklist final | `clean-state-checklist.md` |
+
+Use um documento de exemplo longo para reproduzir o bug antes e depois da correção.
+Uma solução bem-sucedida deve apresentar tanto alterações no código quanto evidências
+de diagnóstico, não apenas uma afirmação de que passou.
+
+## Funcionalidades Cobertas
+
+- Logs de inicialização
+- Logs de importação e indexação
+- Caminho de falha do QA visível
+- Limites explícitos entre as camadas main, preload, renderer e services
+- Depuração de um defeito de execução pré-configurado
+
+## Aulas Relacionadas
+
+- [Aula 07: Por Que Agentes Extrapolam o Escopo e Não Finalizam](../../docs/pt-BR/lectures/lecture-07-why-agents-overreach-and-under-finish/index.md)
+- [Aula 08: Por Que Listas de Funcionalidades São Primitivas de Harness](../../docs/pt-BR/lectures/lecture-08-why-feature-lists-are-harness-primitives/index.md)

--- a/projects/project-05/README-PT-BR.md
+++ b/projects/project-05/README-PT-BR.md
@@ -1,0 +1,60 @@
+# Projeto 05: Loops de Avaliação e Evoluções com Três Papéis
+
+Meça como a separação de papéis (um único papel, gerador mais avaliador, planejador mais gerador mais avaliador) altera a qualidade da implementação.
+
+## Guia de Diretórios
+
+| Diretório | Significado |
+|------|------|
+| `starter/` | **Ponto de partida**: baseado na solução do P4, com o histórico de conversas em múltiplas interações ainda pendente de implementação. |
+| `solution/single-role/` | **Variante A**: um agente faz todo o trabalho (planejamento, implementação e autoavaliação). Qualidade de referência inicial. |
+| `solution/gen-eval/` | **Variante B**: padrão de gerador mais avaliador. Maior qualidade, com evidências de revisão. |
+| `solution/plan-gen-eval/` | **Variante C**: planejador mais gerador mais avaliador. Maior qualidade, com contrato de sprint e critérios de pontuação. |
+
+## Como Usar
+
+```sh
+# Comece pelo starter se quiser executar o exercício por conta própria.
+cd starter
+npm install
+# Implemente a mesma evolução do ConversationHistory três vezes usando a configuração de papéis abaixo.
+
+# Inspecione as três variantes de referência independentemente
+cd solution/single-role && npm install  # modo de papel único
+cd solution/gen-eval && npm install     # modo gerador mais avaliador
+cd solution/plan-gen-eval && npm install # modo completo com três papéis
+
+# Compare as três variantes:
+# - Qualidade do código (pontuação do evaluator-rubric.md)
+# - Quantidade de defeitos encontrados
+# - Quantidade de retrabalho necessário
+```
+
+## Contrato Exato da Tarefa
+
+A evolução do produto para as soluções versionadas é fixa: implemente o histórico de
+perguntas e respostas em múltiplas interações usando `ConversationHistory`. Os três
+diretórios de solução não são etapas sequenciais; são três execuções independentes da
+mesma funcionalidade com diferentes papéis de harness.
+
+| Variante | O que demonstra | Evidência para inspecionar |
+|------|------|------|
+| `starter/` | Aplicação baseada no P4 antes da evolução de histórico de conversas | `src/renderer/components/ConversationHistory.tsx`, `App.tsx` |
+| `solution/single-role/` | Um agente planeja, implementa e faz sua própria revisão | Pontuação 1.6/5 do `evaluator-rubric.md` e defeitos listados |
+| `solution/gen-eval/` | Gerador e avaliador separados com evidências de revisão | Pontuação 3.3/5 do `evaluator-rubric.md` e notas de revisão |
+| `solution/plan-gen-eval/` | Planejador + gerador + avaliador com um contrato de sprint | `sprint-contract.md`, pontuação 4.9/5 do `evaluator-rubric.md` |
+
+Mantenha a funcionalidade constante ao executar novamente o projeto. Alterar a
+funcionalidade entre as variantes invalida a comparação, pois a separação de papéis é
+a única variável pretendida.
+
+## Funcionalidades Cobertas
+
+- Histórico de QA em múltiplas interações (interface conversacional)
+- Contrato de sprint
+- Ajuste de critérios de avaliação do avaliador
+
+## Aulas Relacionadas
+
+- [Aula 09: Por Que Agentes Declaram Vitória Cedo Demais](../../docs/pt-BR/lectures/lecture-09-why-agents-declare-victory-too-early/index.md)
+- [Aula 10: Por Que Testes End-to-End Alteram os Resultados](../../docs/pt-BR/lectures/lecture-10-why-end-to-end-testing-changes-results/index.md)

--- a/projects/project-06/README-PT-BR.md
+++ b/projects/project-06/README-PT-BR.md
@@ -1,0 +1,64 @@
+# Projeto 06: Observabilidade em Tempo de Execução e Depuração (Projeto Final)
+
+Projeto final: construa e avalie um harness completo, depois execute ciclos de limpeza para verificar qualidade e facilidade de manutenção.
+
+## Guia de Diretórios
+
+| Diretório | Significado |
+|------|------|
+| `starter/` | **Ponto de partida**: código completo do produto, mas o harness foi intencionalmente enfraquecido (apenas um `AGENTS.md` básico, sem `feature_list.json`, handoff de sessão ou checklist de estado limpo). |
+| `solution/` | **Implementação de referência**: harness máximo, com todos os arquivos de artefatos presentes, pontuações altas de qualidade da documentação, scripts de benchmark e scanners de limpeza. |
+
+## Como Usar
+
+```sh
+cd starter
+npm install
+# Execute a aplicação e registre manualmente o comportamento com harness fraco.
+# O starter intencionalmente não inclui benchmark.sh ou cleanup-scanner.sh.
+
+cd ../solution
+npm install
+# Execute o mesmo benchmark com o harness completo
+# Execute os ciclos de limpeza
+# Compare as alterações de pontuação no quality-document.md
+
+# Execute os testes de benchmark
+./scripts/benchmark.sh
+
+# Execute a verificação de limpeza
+./scripts/cleanup-scanner.sh
+```
+
+## Contrato Exato da Tarefa
+
+O Projeto 06 é uma comparação final entre um produto completo com uma superfície de
+harness fraca e o mesmo produto fortalecido com artefatos completos de harness. Diferente
+dos projetos anteriores, o starter já contém a maior parte das funcionalidades do produto.
+A diferença está no sistema operacional ao redor do código.
+
+| Área | Estado no Starter | Evidência da Solution |
+|------|------|------|
+| Comportamento do produto | Importação, indexação, QA, histórico, feedback e reset já existem em sua maioria | Mesmas funcionalidades mais validações mais fortes e evidências de persistência |
+| Arquivos de harness | `AGENTS.md` básico, sem `feature_list.json`, sem `session-handoff.md`, sem checklist de estado limpo | `AGENTS.md`, `CLAUDE.md`, `feature_list.json`, `init.sh`, `session-handoff.md`, `clean-state-checklist.md` |
+| Acompanhamento de qualidade | Apenas o `quality-document.md` inicial | `quality-document.md` com pontuação maior, `evaluator-rubric.md` |
+| Benchmarking | Sem scripts de benchmark ou limpeza | `scripts/benchmark.sh`, `scripts/cleanup-scanner.sh`, `scripts/check-architecture.sh` |
+| Documentação de confiabilidade | Documentação mínima | `docs/ARCHITECTURE.md`, `docs/PRODUCT.md`, `docs/RELIABILITY.md` |
+
+Não espere que o starter contenha os comandos de benchmark mostrados para a
+solution. Para a execução com harness fraco, registre observações manuais de
+baseline; para a execução da solution, utilize os scripts de benchmark e limpeza
+versionados no repositório.
+
+## Funcionalidades Cobertas
+
+- Importar documentos
+- Construir ou atualizar o índice
+- Responder perguntas com citações
+- Feedback em tempo de execução
+- Estado do repositório legível e reiniciável
+
+## Aulas Relacionadas
+
+- [Aula 11: Por Que Observabilidade Pertence ao Harness](../../docs/pt-BR/lectures/lecture-11-why-observability-belongs-inside-the-harness/index.md)
+- [Aula 12: Por Que Toda Sessão Deve Deixar um Estado Limpo](../../docs/pt-BR/lectures/lecture-12-why-every-session-must-leave-a-clean-state/index.md)

--- a/skills/README-AR.md
+++ b/skills/README-AR.md
@@ -10,6 +10,7 @@
   <a href="README-VI.md"><img alt="Tiếng_Việt" src="https://img.shields.io/badge/Tiếng_Việt-d9d9d9"></a>
   <a href="README-DE.md"><img alt="Deutsch" src="https://img.shields.io/badge/Deutsch-d9d9d9"></a>
   <a href="README-TR.md"><img alt="Türkçe" src="https://img.shields.io/badge/Türkçe-d9d9d9"></a>
+  <a href="README-PT-BR.md"><img alt="Português (Brasil)" src="https://img.shields.io/badge/Português (Brasil)-d9d9d9"></a>
 </p>
 
 # Skills

--- a/skills/README-CN.md
+++ b/skills/README-CN.md
@@ -10,6 +10,7 @@
   <a href="README-VI.md"><img alt="Tiếng_Việt" src="https://img.shields.io/badge/Tiếng_Việt-d9d9d9"></a>
   <a href="README-DE.md"><img alt="Deutsch" src="https://img.shields.io/badge/Deutsch-d9d9d9"></a>
   <a href="README-TR.md"><img alt="Türkçe" src="https://img.shields.io/badge/Türkçe-d9d9d9"></a>
+  <a href="README-PT-BR.md"><img alt="Português (Brasil)" src="https://img.shields.io/badge/Português (Brasil)-d9d9d9"></a>
 </p>
 
 # Skills（技能集）

--- a/skills/README-DE.md
+++ b/skills/README-DE.md
@@ -10,6 +10,7 @@
   <a href="README-VI.md"><img alt="Tiếng_Việt" src="https://img.shields.io/badge/Tiếng_Việt-d9d9d9"></a>
   <a href="README-DE.md"><img alt="Deutsch" src="https://img.shields.io/badge/Deutsch-d9d9d9"></a>
   <a href="README-TR.md"><img alt="Türkçe" src="https://img.shields.io/badge/Türkçe-d9d9d9"></a>
+  <a href="README-PT-BR.md"><img alt="Português (Brasil)" src="https://img.shields.io/badge/Português (Brasil)-d9d9d9"></a>
 </p>
 
 # Skills

--- a/skills/README-ES.md
+++ b/skills/README-ES.md
@@ -10,6 +10,7 @@
   <a href="README-VI.md"><img alt="Tiếng_Việt" src="https://img.shields.io/badge/Tiếng_Việt-d9d9d9"></a>
   <a href="README-DE.md"><img alt="Deutsch" src="https://img.shields.io/badge/Deutsch-d9d9d9"></a>
   <a href="README-TR.md"><img alt="Türkçe" src="https://img.shields.io/badge/Türkçe-d9d9d9"></a>
+  <a href="README-PT-BR.md"><img alt="Português (Brasil)" src="https://img.shields.io/badge/Português (Brasil)-d9d9d9"></a>
 </p>
 
 # Skills

--- a/skills/README-FR.md
+++ b/skills/README-FR.md
@@ -10,6 +10,7 @@
   <a href="README-VI.md"><img alt="Tiếng_Việt" src="https://img.shields.io/badge/Tiếng_Việt-d9d9d9"></a>
   <a href="README-DE.md"><img alt="Deutsch" src="https://img.shields.io/badge/Deutsch-d9d9d9"></a>
   <a href="README-TR.md"><img alt="Türkçe" src="https://img.shields.io/badge/Türkçe-d9d9d9"></a>
+  <a href="README-PT-BR.md"><img alt="Português (Brasil)" src="https://img.shields.io/badge/Português (Brasil)-d9d9d9"></a>
 </p>
 
 # Skills

--- a/skills/README-JA.md
+++ b/skills/README-JA.md
@@ -10,6 +10,7 @@
   <a href="README-VI.md"><img alt="Tiếng_Việt" src="https://img.shields.io/badge/Tiếng_Việt-d9d9d9"></a>
   <a href="README-DE.md"><img alt="Deutsch" src="https://img.shields.io/badge/Deutsch-d9d9d9"></a>
   <a href="README-TR.md"><img alt="Türkçe" src="https://img.shields.io/badge/Türkçe-d9d9d9"></a>
+  <a href="README-PT-BR.md"><img alt="Português (Brasil)" src="https://img.shields.io/badge/Português (Brasil)-d9d9d9"></a>
 </p>
 
 # Skills

--- a/skills/README-KO.md
+++ b/skills/README-KO.md
@@ -10,6 +10,7 @@
   <a href="README-VI.md"><img alt="Tiếng_Việt" src="https://img.shields.io/badge/Tiếng_Việt-d9d9d9"></a>
   <a href="README-DE.md"><img alt="Deutsch" src="https://img.shields.io/badge/Deutsch-d9d9d9"></a>
   <a href="README-TR.md"><img alt="Türkçe" src="https://img.shields.io/badge/Türkçe-d9d9d9"></a>
+  <a href="README-PT-BR.md"><img alt="Português (Brasil)" src="https://img.shields.io/badge/Português (Brasil)-d9d9d9"></a>
 </p>
 
 # 스킬(Skills)

--- a/skills/README-PT-BR.md
+++ b/skills/README-PT-BR.md
@@ -1,0 +1,73 @@
+# Skills
+
+Este diretório contém skills reutilizáveis de agentes de IA para o projeto Learn Harness Engineering. Cada skill é um template de prompt independente que pode ser carregado por agentes de programação com IA (Claude Code, Codex, Cursor, Windsurf, etc.) para executar tarefas especializadas.
+
+## Skills Disponíveis
+
+### harness-creator
+
+Skill de engenharia de harness para agentes de programação com IA em ambientes de produção. Ajuda a criar, avaliar e melhorar arquivos de harness de agentes (`AGENTS.md`, listas de funcionalidades, fluxos de verificação, mecanismos de continuidade de sessão).
+
+- **7 padrões de referência**: Persistência de Memória, Runtime de Skills, Engenharia de Contexto, Registro de Ferramentas, Coordenação Multiagente, Ciclo de Vida e Bootstrap, Armadilhas
+- **Templates**: `AGENTS.md`/`CLAUDE.md`, `feature-list.json`, `init.sh`, `progress.md`, `session-handoff.md`
+- **Scripts**: criação de estrutura, validação, renderização de avaliação em HTML, execução de benchmark estrutural
+- **10 casos de teste de avaliação integrados**
+
+Consulte [harness-creator/README.md](harness-creator/README.md) para a documentação completa.
+
+## Como o harness-creator Foi Criado
+
+A skill `harness-creator` foi desenvolvida usando a metodologia **skill-creator** — a meta-skill oficial da Anthropic para criar, testar e iterar sobre skills de agentes. O skill-creator fornece um fluxo de trabalho estruturado (rascunho → teste → avaliação → iteração) com executores de avaliação, avaliadores e um visualizador de benchmark integrados.
+
+- **Fonte do skill-creator**: [anthropics/skills — skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator)
+- **Documentação de skills do Claude Code da Anthropic**: [anthropics/claude-code — plugin-dev/skills](https://github.com/anthropics/claude-code/tree/main/plugins/plugin-dev/skills)
+
+## Estrutura de Diretórios
+```
+skills/
+├── README.md                    # Este arquivo
+├── README-CN.md                 # Versão em chinês
+├── README-ZH-TW.md              # Versão em chinês tradicional
+├── README-JA.md                 # Versão em japonês
+├── README-ES.md                 # Versão em espanhol
+├── README-FR.md                 # Versão em francês
+├── README-AR.md                 # Versão em árabe
+├── README-VI.md                 # Versão em vietnamita
+├── README-DE.md                 # Versão em alemão
+├── README-TR.md                 # Versão em turco
+├── README-PT-BR.md              # Versão em português (Brasil)
+└── harness-creator/             # Skill de engenharia de harness
+    ├── SKILL.md                 # Definição principal do skill
+    ├── SKILL.md.en              # Versão apenas em inglês
+    ├── README.md                # Documentação detalhada
+    ├── metadata.json            # Metadados e gatilhos do skill
+    ├── agents/                  # Metadados da UI do skill
+    ├── scripts/                 # Auxiliares de scaffold, validação, benchmark
+    ├── evals/                   # Casos de teste
+    ├── templates/               # Templates de scaffold
+    └── references/              # Documentos de padrões detalhados
+```
+
+## Como as Skills Funcionam
+
+Cada skill segue uma estrutura padrão:
+
+1. **SKILL.md** — O ponto de entrada. Contém frontmatter YAML (nome, descrição para acionamento) e instruções em Markdown para o agente.
+2. **references/** — Documentos adicionais carregados no contexto conforme necessário.
+3. **templates/** — Templates iniciais que a skill pode gerar para os usuários.
+
+As skills utilizam divulgação progressiva — o agente primeiro visualiza apenas o nome + descrição, depois carrega o conteúdo completo do SKILL.md quando acionado e lê os recursos incluídos somente quando necessário.
+
+## Auditoria de Segurança
+
+Todos os arquivos deste diretório foram auditados para segurança:
+
+- Sem backdoors, URLs ocultas ou payloads codificados
+- Sem exfiltração de dados ou credenciais armazenadas diretamente no código
+- Sem vulnerabilidades de injeção de comandos
+- Os scripts utilizam apenas módulos nativos do Node.js
+- O `init.sh` gerado executa comandos de verificação detectados do projeto
+
+## Licença
+
+MIT

--- a/skills/README-TR.md
+++ b/skills/README-TR.md
@@ -10,6 +10,7 @@
   <a href="README-VI.md"><img alt="Tiếng_Việt" src="https://img.shields.io/badge/Tiếng_Việt-d9d9d9"></a>
   <a href="README-DE.md"><img alt="Deutsch" src="https://img.shields.io/badge/Deutsch-d9d9d9"></a>
   <a href="README-TR.md"><img alt="Türkçe" src="https://img.shields.io/badge/Türkçe-d9d9d9"></a>
+  <a href="README-PT-BR.md"><img alt="Português (Brasil)" src="https://img.shields.io/badge/Português (Brasil)-d9d9d9"></a>
 </p>
 
 # Skill'ler

--- a/skills/README-VI.md
+++ b/skills/README-VI.md
@@ -10,6 +10,7 @@
   <a href="README-VI.md"><img alt="Tiếng_Việt" src="https://img.shields.io/badge/Tiếng_Việt-d9d9d9"></a>
   <a href="README-DE.md"><img alt="Deutsch" src="https://img.shields.io/badge/Deutsch-d9d9d9"></a>
   <a href="README-TR.md"><img alt="Türkçe" src="https://img.shields.io/badge/Türkçe-d9d9d9"></a>
+  <a href="README-PT-BR.md"><img alt="Português (Brasil)" src="https://img.shields.io/badge/Português (Brasil)-d9d9d9"></a>
 </p>
 
 # Skills

--- a/skills/README-ZH-TW.md
+++ b/skills/README-ZH-TW.md
@@ -10,6 +10,7 @@
   <a href="README-VI.md"><img alt="Tiếng_Việt" src="https://img.shields.io/badge/Tiếng_Việt-d9d9d9"></a>
   <a href="README-DE.md"><img alt="Deutsch" src="https://img.shields.io/badge/Deutsch-d9d9d9"></a>
   <a href="README-TR.md"><img alt="Türkçe" src="https://img.shields.io/badge/Türkçe-d9d9d9"></a>
+  <a href="README-PT-BR.md"><img alt="Português (Brasil)" src="https://img.shields.io/badge/Português (Brasil)-d9d9d9"></a>
 </p>
 
 # Skills（技能集）

--- a/skills/README.md
+++ b/skills/README.md
@@ -10,6 +10,7 @@
   <a href="README-VI.md"><img alt="Tiếng_Việt" src="https://img.shields.io/badge/Tiếng_Việt-d9d9d9"></a>
   <a href="README-DE.md"><img alt="Deutsch" src="https://img.shields.io/badge/Deutsch-d9d9d9"></a>
   <a href="README-TR.md"><img alt="Türkçe" src="https://img.shields.io/badge/Türkçe-d9d9d9"></a>
+  <a href="README-PT-BR.md"><img alt="Português (Brasil)" src="https://img.shields.io/badge/Português (Brasil)-d9d9d9"></a>
 </p>
 
 # Skills
@@ -50,6 +51,7 @@ skills/
 ├── README-VI.md                 # Vietnamese version
 ├── README-DE.md                 # German version
 ├── README-TR.md                 # Turkish version
+├── README-PT-BR.md              # Portuguese (Brazil) version
 └── harness-creator/             # Harness engineering skill
     ├── SKILL.md                 # Main skill definition
     ├── SKILL.md.en              # English-only version


### PR DESCRIPTION
## Overview
This PR adds comprehensive Portuguese (BR) localization for the Learn Harness Engineering course materials, including all 6 projects and skills documentation.

## Changes
- Added Portuguese (Brazil) `README-PT-BR.md` files for all projects (Project 01–06)
- Updated main Portuguese README with comprehensive course content
- Added Portuguese translation for skills documentation

## Files Changed
- `projects/project-01/README-PT-BR.md` — Baseline vs Harness
- `projects/project-02/README-PT-BR.md` — Workspace Agent Readability
- `projects/project-03/README-PT-BR.md` — Session Continuity
- `projects/project-04/README-PT-BR.md` — Documentation and Type Safety
- `projects/project-05/README-PT-BR.md` — Evaluation Loops
- `projects/project-06/README-PT-BR.md` — Observability Harness
- `docs/pt-BR/` — Updated main course README and skills documentation

## Why
Expands course accessibility and learning materials to Portuguese-speaking audiences, following the existing multi-language support pattern established for other locales (EN, ZH, KO, etc.).