### PR TITLE
Fix broken HumanLayer link across all 15 locales

### DIFF
--- a/docs/ar/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/ar/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -104,7 +104,7 @@ Completion criteria:
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Leaderboard](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/ar/lectures/lecture-02-what-a-harness-actually-is/index.md
+++ b/docs/ar/lectures/lecture-02-what-a-harness-actually-is/index.md
@@ -96,7 +96,7 @@ Verification commands:
 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 - [Thoughtworks: Harness Engineering on Technology Radar](https://www.thoughtworks.com/radar)
 

--- a/docs/ar/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/ar/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -120,7 +120,7 @@ Python 3.11 FastAPI backend, PostgreSQL 15 database.
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## تمارين

--- a/docs/ar/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/ar/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -169,7 +169,7 @@ flowchart LR
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Documentation](https://docs.anthropic.com/ar/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## تمارين
 

--- a/docs/ar/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/ar/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -144,7 +144,7 @@ flowchart TB
 
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 

--- a/docs/de/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/de/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -104,7 +104,7 @@ Sie änderten nicht das Modell. Sie änderten den Harness.
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Leaderboard](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/de/lectures/lecture-02-what-a-harness-actually-is/index.md
+++ b/docs/de/lectures/lecture-02-what-a-harness-actually-is/index.md
@@ -96,7 +96,7 @@ Vier Iterationen, das Modell hat sich gar nicht geändert, die Erfolgsquote stie
 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 - [Thoughtworks: Harness Engineering on Technology Radar](https://www.thoughtworks.com/radar)
 

--- a/docs/de/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/de/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -120,7 +120,7 @@ Nach dem Refactoring stieg die Erfolgsrate desselben Aufgabensatzes von 45% auf 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## Übungen

--- a/docs/de/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/de/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -169,7 +169,7 @@ Quantitativer Vergleich: Rebuild-Zeit um ~78% reduziert, Feature-Abschlussrate v
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Documentation](https://docs.anthropic.com/de/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## Übungen
 

--- a/docs/de/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/de/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -144,7 +144,7 @@ Vergleich über den gesamten Projektzyklus: Die gesamte Rebuild-Zeit des gemisch
 
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 

--- a/docs/en/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/en/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -90,7 +90,7 @@ They didn't change the model. They changed the harness.
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Leaderboard](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/en/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/en/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -120,7 +120,7 @@ After refactoring: success rate on the same task set improved from 45% to 72%. S
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## Exercises

--- a/docs/en/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/en/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -167,7 +167,7 @@ Quantitative comparison: rebuild time reduced ~78%, feature completion rate from
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## Exercises
 

--- a/docs/en/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/en/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -144,7 +144,7 @@ Full project cycle comparison: the mixed approach's total rebuild time (across a
 
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 

--- a/docs/es/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/es/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -104,7 +104,7 @@ No cambiaron el modelo. Cambiaron el harness.
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Leaderboard](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/es/lectures/lecture-02-what-a-harness-actually-is/index.md
+++ b/docs/es/lectures/lecture-02-what-a-harness-actually-is/index.md
@@ -96,7 +96,7 @@ Cuatro iteraciones, el modelo no cambió en absoluto, la tasa de éxito pasó de
 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 - [Thoughtworks: Harness Engineering on Technology Radar](https://www.thoughtworks.com/radar)
 

--- a/docs/es/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/es/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -120,7 +120,7 @@ Después de refactorizar, la tasa de éxito del mismo conjunto de tareas pasó d
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## Ejercicios

--- a/docs/es/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/es/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -169,7 +169,7 @@ Comparación cuantitativa: tiempo de reconstrucción reducido ~78%, tasa de comp
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Documentation](https://docs.anthropic.com/es/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## Ejercicios
 

--- a/docs/es/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/es/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -144,7 +144,7 @@ Comparación del ciclo completo del proyecto: el tiempo total de reconstrucción
 
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 

--- a/docs/fr/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/fr/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -100,7 +100,7 @@ Ils n'ont pas changé le modèle. Ils ont changé le harness.
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Leaderboard](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/fr/lectures/lecture-02-what-a-harness-actually-is/index.md
+++ b/docs/fr/lectures/lecture-02-what-a-harness-actually-is/index.md
@@ -96,7 +96,7 @@ Quatre itérations, le modèle n'a pas du tout changé, le taux de réussite est
 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 - [Thoughtworks: Harness Engineering on Technology Radar](https://www.thoughtworks.com/radar)
 

--- a/docs/fr/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/fr/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -120,7 +120,7 @@ Après refactorisation, le taux de réussite du même ensemble de tâches est pa
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## Exercices

--- a/docs/fr/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/fr/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -169,7 +169,7 @@ Comparaison quantitative : temps de reconstruction réduit de ~78 %, taux de com
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Documentation](https://docs.anthropic.com/fr/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## Exercices
 

--- a/docs/fr/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/fr/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -144,7 +144,7 @@ Comparaison sur le cycle complet du projet : le temps de reconstruction total de
 
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 

--- a/docs/ja/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/ja/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -104,7 +104,7 @@ OpenAI は 2025 年に強烈な実験を行いました。空の git リポジ�
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Leaderboard](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/ja/lectures/lecture-02-what-a-harness-actually-is/index.md
+++ b/docs/ja/lectures/lecture-02-what-a-harness-actually-is/index.md
@@ -96,7 +96,7 @@ Verification commands:
 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 - [Thoughtworks: Harness Engineering on Technology Radar](https://www.thoughtworks.com/radar)
 

--- a/docs/ja/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/ja/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -120,7 +120,7 @@ OpenAI と Anthropic はどちらも、暗黙に分割アプローチを支持�
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## 演習

--- a/docs/ja/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/ja/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -169,7 +169,7 @@ Anthropic の実際のデータ: Sonnet 4.5 では、コンテキスト不安が
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Documentation](https://docs.anthropic.com/ja/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## 演習
 

--- a/docs/ja/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/ja/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -144,7 +144,7 @@ React フロントエンドプロジェクトの2つの初期化アプローチ:
 
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 

--- a/docs/ko/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/ko/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -108,7 +108,7 @@ OpenAI는 2025년에 공격적인 실험을 진행했습니다: Codex를 사용�
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Leaderboard](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/ko/lectures/lecture-02-what-a-harness-actually-is/index.md
+++ b/docs/ko/lectures/lecture-02-what-a-harness-actually-is/index.md
@@ -96,7 +96,7 @@ flowchart LR
 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 - [Thoughtworks: Harness Engineering on Technology Radar](https://www.thoughtworks.com/radar)
 

--- a/docs/ko/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/ko/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -120,7 +120,7 @@ OpenAI와 Anthropic 모두 분산 접근 방식을 암묵적으로 지지합니�
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## 연습 문제

--- a/docs/ko/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/ko/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -169,7 +169,7 @@ Anthropic의 실제 데이터: Sonnet 4.5에서 컨텍스트 불안이 심각해
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## 연습 문제
 

--- a/docs/ko/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/ko/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -144,7 +144,7 @@ React 프론트엔드 프로젝트에 대한 두 가지 초기화 접근법:
 
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 

--- a/docs/pt-BR/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/pt-BR/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -90,7 +90,7 @@ Eles não mudaram o modelo. Mudaram o harness.
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Leaderboard](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/pt-BR/lectures/lecture-02-what-a-harness-actually-is/index.md
+++ b/docs/pt-BR/lectures/lecture-02-what-a-harness-actually-is/index.md
@@ -95,7 +95,7 @@ Foram quatro iterações, o modelo não mudou em nenhum momento, e a taxa de suc
 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Harnesses Eficazes para Agentes de Longa Duração](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Harness Engineering para Agentes de Programação](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering para Agentes de Programação](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-agent: Interfaces entre Agentes e Computadores](https://github.com/princeton-nlp/SWE-agent)
 - [Thoughtworks: Harness Engineering no Technology Radar](https://www.thoughtworks.com/radar)
 

--- a/docs/pt-BR/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/pt-BR/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -131,7 +131,7 @@ Após a refatoração: a taxa de sucesso no mesmo conjunto de tarefas subiu de 4
 * [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 * [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 * [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-* [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+* [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 * [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## Exercícios

--- a/docs/pt-BR/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/pt-BR/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -165,7 +165,7 @@ Comparação quantitativa: o tempo de reconstrução foi reduzido em aproximadam
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## Exercícios
 

--- a/docs/pt-BR/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/pt-BR/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -150,7 +150,7 @@ Comparação do ciclo completo do projeto: a abordagem mista apresentou um tempo
 
 - [Anthropic: Harnesses eficazes para agentes de longa duração](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering para Agentes de Programação](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering para Agentes de Programação](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Interfaces entre Agentes e Computadores](https://github.com/princeton-nlp/SWE-agent)
 

--- a/docs/ru/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/ru/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -104,7 +104,7 @@ Anthropic провели контролируемый эксперимент. О
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Leaderboard](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/ru/lectures/lecture-02-what-a-harness-actually-is/index.md
+++ b/docs/ru/lectures/lecture-02-what-a-harness-actually-is/index.md
@@ -96,7 +96,7 @@ flowchart LR
 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 - [Thoughtworks: Harness Engineering on Technology Radar](https://www.thoughtworks.com/radar)
 

--- a/docs/ru/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/ru/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -120,7 +120,7 @@ Python 3.11 FastAPI backend, PostgreSQL 15 database.
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## Упражнения

--- a/docs/ru/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/ru/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -169,7 +169,7 @@ flowchart LR
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## Упражнения
 

--- a/docs/ru/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/ru/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -144,7 +144,7 @@ flowchart TB
 
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 

--- a/docs/tr/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/tr/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -104,7 +104,7 @@ Modeli değiştirmediler. Harness'ı değiştirdiler.
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Liderlik Tablosu](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/tr/lectures/lecture-02-what-a-harness-actually-is/index.md
+++ b/docs/tr/lectures/lecture-02-what-a-harness-actually-is/index.md
@@ -96,7 +96,7 @@ Dört iterasyon, model hiç değişmedi, başarı oranı %20'den neredeyse %100'
 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 - [Thoughtworks: Harness Engineering on Technology Radar](https://www.thoughtworks.com/radar)
 

--- a/docs/tr/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/tr/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -120,7 +120,7 @@ Yeniden yapılandırmadan sonra: aynı görev setinin başarı oranı %45'ten %7
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## Alıştırmalar

--- a/docs/tr/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/tr/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -169,7 +169,7 @@ Nicel karşılaştırma: yeniden inşa süresi ~%78 azaldı, özellik tamamlanma
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Dokümantasyonu](https://docs.anthropic.com/en/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## Alıştırmalar
 

--- a/docs/tr/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/tr/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -144,7 +144,7 @@ Tam proje döngüsü karşılaştırması: karışık yaklaşımın toplam yenid
 
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 

--- a/docs/uk/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/uk/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -90,7 +90,7 @@ Anthropic провела контрольований експеримент, я
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Leaderboard](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/uk/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/uk/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -120,7 +120,7 @@ Python 3.11 FastAPI backend, PostgreSQL 15 database.
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## Вправи

--- a/docs/uk/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/uk/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -167,7 +167,7 @@ flowchart LR
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## Вправи
 

--- a/docs/uk/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/uk/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -144,7 +144,7 @@ flowchart TB
 
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 

--- a/docs/uz/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/uz/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -105,7 +105,7 @@ Ular modelni oʻzgartirmadi. Ular harnessʼni oʻzgartirdi.
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Leaderboard](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/uz/lectures/lecture-02-what-a-harness-actually-is/index.md
+++ b/docs/uz/lectures/lecture-02-what-a-harness-actually-is/index.md
@@ -96,7 +96,7 @@ Toʻrtta iteratsiya, model umuman oʻzgarmadi, muvaffaqiyat koʻrsatkichi 20% da
 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 - [Thoughtworks: Harness Engineering on Technology Radar](https://www.thoughtworks.com/radar)
 

--- a/docs/uz/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/uz/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -120,7 +120,7 @@ Refaktoringdan soʻng: xuddi oʻsha vazifalar toʻplamini muvaffaqiyatli bajaris
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## Mashqlar

--- a/docs/uz/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/uz/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -169,7 +169,7 @@ Miqdoriy taqqoslash: tiklash vaqti ~78% ga qisqardi, funksiyalarning tugallanish
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## Mashqlar
 

--- a/docs/uz/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/uz/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -144,7 +144,7 @@ Loyiha sikllarini toʻliq taqqoslash: aralash usuldagi umumiy tiklash vaqti (bar
 
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 

--- a/docs/vi/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/vi/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -90,7 +90,7 @@ Họ không thay đổi mô hình. Họ thay đổi harness.
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Leaderboard](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/vi/lectures/lecture-02-what-a-harness-actually-is/index.md
+++ b/docs/vi/lectures/lecture-02-what-a-harness-actually-is/index.md
@@ -96,7 +96,7 @@ Bốn vòng lặp, mô hình không hề thay đổi, mà tỷ lệ thành công
 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 - [Thoughtworks: Harness Engineering on Technology Radar](https://www.thoughtworks.com/radar)
 

--- a/docs/vi/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/vi/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -120,7 +120,7 @@ Sau tái cấu trúc: tỷ lệ thành công trên cùng bộ tác vụ tăng t�
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## Bài tập

--- a/docs/vi/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/vi/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -169,7 +169,7 @@ So sánh định lượng: thời gian tái thiết lập giảm khoảng 78%, t
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## Bài tập
 

--- a/docs/vi/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/vi/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -144,7 +144,7 @@ So sánh toàn chu kỳ dự án: tổng thời gian tái thiết lập (cộng 
 
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 

--- a/docs/zh-TW/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/zh-TW/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -100,7 +100,7 @@ OpenAI 在 2025 年做了一個激進的實驗，用 Codex 從一個空的 git �
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Leaderboard](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/zh-TW/lectures/lecture-02-what-a-harness-actually-is/index.md
+++ b/docs/zh-TW/lectures/lecture-02-what-a-harness-actually-is/index.md
@@ -96,7 +96,7 @@ flowchart LR
 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 - [Thoughtworks: Harness Engineering on Technology Radar](https://www.thoughtworks.com/radar)
 

--- a/docs/zh-TW/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/zh-TW/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -120,7 +120,7 @@ Agent 表現開始明顯下降：簡單 bug 修復任務中 agent 花大量脈�
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## 練習

--- a/docs/zh-TW/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/zh-TW/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -167,7 +167,7 @@ Anthropic 的實際資料：對於 Sonnet 4.5，脈絡焦慮足夠嚴重，以�
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## 練習
 

--- a/docs/zh-TW/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/zh-TW/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -144,7 +144,7 @@ OpenAI 的 Codex harness engineering 指南也強調「儲存庫作為操作記�
 
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 

--- a/docs/zh/lectures/lecture-01-why-capable-agents-still-fail/index.md
+++ b/docs/zh/lectures/lecture-01-why-capable-agents-still-fail/index.md
@@ -90,7 +90,7 @@ OpenAI 在 2025 年的 harness engineering 文章里把这件事说得更直白�
 
 - [OpenAI: Harness Engineering — Leveraging Codex in an Agent-First World](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Skill Issue — Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-bench Leaderboard](https://www.swebench.com/)
 - [Thoughtworks Technology Radar: Harness Engineering](https://www.thoughtworks.com/radar)
 

--- a/docs/zh/lectures/lecture-02-what-a-harness-actually-is/index.md
+++ b/docs/zh/lectures/lecture-02-what-a-harness-actually-is/index.md
@@ -96,7 +96,7 @@ flowchart LR
 
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 - [Thoughtworks: Harness Engineering on Technology Radar](https://www.thoughtworks.com/radar)
 

--- a/docs/zh/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
+++ b/docs/zh/lectures/lecture-04-why-one-giant-instruction-file-fails/index.md
@@ -120,7 +120,7 @@ Agent 表现开始明显下降：简单 bug 修复任务中 agent 花大量上�
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Nielsen Norman Group: Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
 
 ## 练习

--- a/docs/zh/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
+++ b/docs/zh/lectures/lecture-05-why-long-running-tasks-lose-continuity/index.md
@@ -167,7 +167,7 @@ Anthropic 的实际数据：对于 Sonnet 4.5，上下文焦虑足够严重，�
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
 - [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172)
 - [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 
 ## 练习
 

--- a/docs/zh/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
+++ b/docs/zh/lectures/lecture-06-why-initialization-needs-its-own-phase/index.md
@@ -144,7 +144,7 @@ OpenAI 的 Codex harness engineering 指南也强调"仓库作为操作记录"�
 
 - [Anthropic: Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
 - [OpenAI: Harness Engineering](https://openai.com/index/harness-engineering/)
-- [HumanLayer: Harness Engineering for Coding Agents](https://humanlayer.dev/articles/harness-engineering-for-coding-agents/)
+- [HumanLayer: Harness Engineering for Coding Agents](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents)
 - [Infrastructure as Code — Martin Fowler](https://martinfowler.com/bliki/InfrastructureAsCode.html)
 - [SWE-agent: Agent-Computer Interfaces](https://github.com/princeton-nlp/SWE-agent)
 


### PR DESCRIPTION
The old link `https://humanlayer.dev/articles/harness-engineering-for-coding-agents/` returns 404 (the article moved from `/articles/` to `/blog/` on humanlayer.dev, no redirect set up).

Updated to `https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents` across all **15 locales** (ar, de, en, es, fr, ja, ko, pt-BR, ru, tr, uk, uz, vi, zh, zh-TW) in lectures **01, 02, 04, 05, 06**.

The new page title ("Skill Issue: Harness Engineering for Coding Agents") matches the link text used in lecture-01. The shorter text in other lectures ("HumanLayer: Harness Engineering for Coding Agents") is a subset of the same title.

73 files changed, 73 insertions(+), 73 deletions(-)