### PR TITLE
fix: restore Star History chart with working endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,12 @@ Our team has also created other courses! Check them out:
 
 ---
 
+## Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## Acknowledgments
 
 This course was inspired by and draws ideas from [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) — a progressive guide to building an agent from scratch, from a single loop to isolated autonomous execution.

--- a/docs-readme/ar-SA/README.md
+++ b/docs-readme/ar-SA/README.md
@@ -630,6 +630,12 @@ learn-harness-engineering/
 
 ---
 
+## تاريخ النجوم
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## شكر وتقدير
 
 هذه الدورة مستوحاة وتستمد أفكاراً من [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) — دليل تدريجي لبناء وكيل من الصفر، من حلقة واحدة إلى تنفيذ مستقل معزول.

--- a/docs-readme/de-DE/README.md
+++ b/docs-readme/de-DE/README.md
@@ -633,6 +633,12 @@ Unser Team hat auch weitere Kurse erstellt! Schauen Sie sich diese an:
 
 ---
 
+## Star-History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## Danksagungen
 
 Dieser Kurs wurde inspiriert von und bezieht Ideen aus [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) — einem fortschreitenden Leitfaden zum Aufbau eines Agenten von Grund auf, von einem einzelnen Loop bis zur isolierten autonomen Ausführung.

--- a/docs-readme/es-ES/README.md
+++ b/docs-readme/es-ES/README.md
@@ -636,6 +636,12 @@ Nuestro equipo también ha creado otros cursos! Échales un vistazo:
 
 ---
 
+## Historial de Estrellas
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## Agradecimientos
 
 Este curso fue inspirado por y toma ideas de [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) — una guía progresiva para construir un agente desde cero, desde un simple bucle hasta la ejecución autónoma aislada.

--- a/docs-readme/fr-FR/README.md
+++ b/docs-readme/fr-FR/README.md
@@ -632,6 +632,12 @@ Notre équipe a également créé d'autres cours ! Découvrez-les :
 
 ---
 
+## Historique des Étoiles
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## Remerciements
 
 Ce cours a été inspiré par et puise ses idées dans [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) -- un guide progressif pour construire un agent à partir de zéro, d'une simple boucle à l'exécution autonome isolée.

--- a/docs-readme/ja-JP/README.md
+++ b/docs-readme/ja-JP/README.md
@@ -629,6 +629,12 @@ learn-harness-engineering/
 
 ---
 
+## スター履歴
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## 謝辞
 
 このコースは [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) にインスピレーションを受け、アイデアを得ています — 単一のループから独立した自律実行まで、ゼロからエージェントを構築する段階的ガイド。

--- a/docs-readme/ko-KR/README.md
+++ b/docs-readme/ko-KR/README.md
@@ -627,6 +627,12 @@ learn-harness-engineering/
 
 ---
 
+## 스타 히스토리
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## 감사의 글
 
 이 강좌는 [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code)에서 영감을 받고 아이디어를 얻었습니다 — 단일 루프에서 격리된 자율 실행까지, 에이전트를 처음부터 구축하는 점진적 가이드입니다.

--- a/docs-readme/pt-BR/README.md
+++ b/docs-readme/pt-BR/README.md
@@ -651,6 +651,12 @@ Nossa equipe também criou outros cursos! Confira-os:
 
 ---
 
+## Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## Agradecimentos
 
 Este curso foi inspirado e extrai ideias de [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) — um guia progressivo para construir um agente do zero, de um único loop à execução autônoma isolada.

--- a/docs-readme/ru-RU/README.md
+++ b/docs-readme/ru-RU/README.md
@@ -641,6 +641,12 @@ learn-harness-engineering/
 
 ---
 
+## История звёзд
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## Благодарности
 
 Этот курс вдохновлён и содержит идеи из [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) — прогрессивного руководства по созданию агента с нуля, от единственного цикла до изолированного автономного выполнения.

--- a/docs-readme/tr-TR/README.md
+++ b/docs-readme/tr-TR/README.md
@@ -629,6 +629,12 @@ Ekibimiz başka kurslar da hazırladı! Göz atın:
 
 ---
 
+## Yıldız Geçmişi
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## Teşekkürler
 
 Bu kurs, [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code)'dan ilham aldı ve fikirler ödünç aldı — tek bir döngüden izole özerk yürütmeye, bir ajanı sıfırdan inşa etmeye yönelik aşamalı bir rehber.

--- a/docs-readme/uk-UA/README.md
+++ b/docs-readme/uk-UA/README.md
@@ -640,6 +640,12 @@ learn-harness-engineering/
 
 ---
 
+## Історія зірок
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## Подяки
 
 Цей курс натхненний та черпає ідеї з [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) — покрокового посібника з побудови агента з нуля, від простого циклу до ізольованого автономного виконання.

--- a/docs-readme/uz-UZ/README.md
+++ b/docs-readme/uz-UZ/README.md
@@ -632,6 +632,12 @@ Bizning jamoamiz yana boshqa kurslar ham yaratdi! Ularni koʻrib chiqing:
 
 ---
 
+## Yulduzlar tarixi
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## Minnatdorchilik
 
 Ushbu kurs [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) dan ilhomlangan va undan gʻoyalar olgan — agentni bitta sikldan izolyatsiya qilingan avtonom bajarishgacha noldan qurish boʻyicha progressiv qoʻllanma.

--- a/docs-readme/vi-VN/README.md
+++ b/docs-readme/vi-VN/README.md
@@ -635,6 +635,12 @@ Kho lưu trữ này cũng bao gồm các skill agent AI có thể tái sử dụ
 
 ---
 
+## Lịch sử Star
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## Lời cảm ơn
 
 Khóa học này được truyền cảm hứng và rút ra ý tưởng từ [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) — một hướng dẫn tiệm tiến về việc xây dựng một agent từ đầu, từ một vòng lặp đơn giản đến thực thi tự chủ cô lập.

--- a/docs-readme/zh-CN/README.md
+++ b/docs-readme/zh-CN/README.md
@@ -629,6 +629,12 @@ learn-harness-engineering/
 
 ---
 
+## Star 历史
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## 致谢
 
 本课程受到 [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) 的启发并借鉴了其中的理念——那是一份从单循环到隔离自主执行的渐进式代理构建指南。

--- a/docs-readme/zh-TW/README.md
+++ b/docs-readme/zh-TW/README.md
@@ -617,6 +617,12 @@ learn-harness-engineering/
 
 ---
 
+## Star 歷史
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=walkinglabs/learn-harness-engineering&type=date&legend=top-left)](https://star-history.dera.page/#walkinglabs/learn-harness-engineering&type=date&legend=top-left)
+
+---
+
 ## 致謝
 
 本課程的靈感來源和部分理念取自 [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) —— 一份從零建構代理的漸進式指南，從單一迴圈到隔離的自主執行。


### PR DESCRIPTION
The Star History chart stopped rendering because the upstream service it relied on no longer works under GitHub's stargazer API restrictions.

The section was previously dropped entirely in a703dbd ("Add 前沿 Harness 拆解 column and remove Star History blocks") to work around the breakage. Instead of leaving the repository without a stargazer history section, this PR restores it on a working chart service.

Changes:
- Re-add the Star History section to README.md and all 14 localized readmes
- Point the chart and its link to the working service

All 15 readmes are updated so the section renders consistently across locales.