### PR TITLE
docs: add Hindi and Urdu translations for skills/README.md

### DIFF
--- a/skills/README-HI.md
+++ b/skills/README-HI.md
@@ -1,0 +1,95 @@
+<p align="center">
+  <a href="README.md"><img alt="English" src="https://img.shields.io/badge/English-d9d9d9"></a>
+  <a href="README-CN.md"><img alt="简体中文" src="https://img.shields.io/badge/简体中文-d9d9d9"></a>
+  <a href="README-ZH-TW.md"><img alt="繁體中文" src="https://img.shields.io/badge/繁體中文-d9d9d9"></a>
+  <a href="README-JA.md"><img alt="日本語" src="https://img.shields.io/badge/日本語-d9d9d9"></a>
+  <a href="README-ES.md"><img alt="Español" src="https://img.shields.io/badge/Español-d9d9d9"></a>
+  <a href="README-FR.md"><img alt="Français" src="https://img.shields.io/badge/Français-d9d9d9"></a>
+  <a href="README-KO.md"><img alt="한국어" src="https://img.shields.io/badge/한국어-d9d9d9"></a>
+  <a href="README-AR.md"><img alt="العربية" src="https://img.shields.io/badge/العربية-d9d9d9"></a>
+  <a href="README-VI.md"><img alt="Tiếng_Việt" src="https://img.shields.io/badge/Tiếng_Việt-d9d9d9"></a>
+  <a href="README-DE.md"><img alt="Deutsch" src="https://img.shields.io/badge/Deutsch-d9d9d9"></a>
+  <a href="README-TR.md"><img alt="Türkçe" src="https://img.shields.io/badge/Türkçe-d9d9d9"></a>
+  <a href="README-PT-BR.md"><img alt="Português (Brasil)" src="https://img.shields.io/badge/Português (Brasil)-d9d9d9"></a>
+  <a href="README-UK.md"><img alt="Українська" src="https://img.shields.io/badge/Українська-d9d9d9"></a>
+  <a href="README-HI.md"><img alt="हिन्दी" src="https://img.shields.io/badge/Hindi-d9d9d9"></a>
+  <a href="README-UR.md"><img alt="اردو" src="https://img.shields.io/badge/اردو-d9d9d9"></a>
+</p>
+
+# Skills
+
+यह डायरेक्टरी Learn Harness Engineering प्रोजेक्ट के लिए पुन: उपयोग किए जा सकने वाले AI agent skills प्रदान करती है। प्रत्येक skill एक self-contained prompt template है जिसे AI coding agents (Claude Code, Codex, Cursor, Windsurf, आदि) विशेष कार्यों को करने के लिए load कर सकते हैं।
+
+## उपलब्ध Skills
+
+### harness-creator
+
+AI coding agents के लिए production harness engineering skill। agent harness files (AGENTS.md, feature lists, verification workflows, session continuity mechanisms) बनाने, मूल्यांकन करने और सुधारने में मदद करता है।
+
+- **7 reference patterns**: Memory Persistence, Skill Runtime, Context Engineering, Tool Registry, Multi-Agent Coordination, Lifecycle & Bootstrap, Gotchas
+- **Templates**: AGENTS.md/CLAUDE.md, feature-list.json, init.sh, progress.md, session-handoff.md
+- **Scripts**: scaffold, validate, render HTML assessment, run structural benchmark
+- **10 built-in eval test cases**
+
+पूर्ण दस्तावेज़ के लिए [harness-creator/README.md](harness-creator/README.md) देखें।
+
+## harness-creator कैसे बनाया गया
+
+`harness-creator` skill को **skill-creator** methodology का उपयोग करके विकसित किया गया था — agent skills बनाने, परीक्षण करने और iterate करने के लिए Anthropic का आधिकारिक meta-skill। skill-creator एक structured workflow (draft → test → evaluate → iterate) प्रदान करता है जिसमें built-in eval runners, graders, और एक benchmark viewer शामिल हैं।
+
+- **skill-creator source**: [anthropics/skills — skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator)
+- **Anthropic Claude Code skills docs**: [anthropics/claude-code — plugin-dev/skills](https://github.com/anthropics/claude-code/tree/main/plugins/plugin-dev/skills)
+
+## डायरेक्टरी संरचना
+
+```
+skills/
+├── README.md                    # यह फ़ाइल
+├── README-CN.md                 # चीनी संस्करण
+├── README-ZH-TW.md              # पारंपरिक चीनी संस्करण
+├── README-JA.md                 # जापानी संस्करण
+├── README-ES.md                 # स्पेनिश संस्करण
+├── README-FR.md                 # फ्रेंच संस्करण
+├── README-AR.md                 # अरबी संस्करण
+├── README-VI.md                 # वियतनामी संस्करण
+├── README-DE.md                 # जर्मन संस्करण
+├── README-TR.md                 # तुर्की संस्करण
+├── README-PT-BR.md              # पुर्तगाली (ब्राज़ील) संस्करण
+├── README-UK.md                 # यूक्रेनी संस्करण
+├── README-HI.md                 # हिंदी संस्करण
+├── README-UR.md                 # اردو نسخہ
+└── harness-creator/             # Harness engineering skill
+    ├── SKILL.md                 # मुख्य skill definition
+    ├── SKILL.md.en              # केवल अंग्रेज़ी संस्करण
+    ├── README.md                # विस्तृत दस्तावेज़
+    ├── metadata.json            # Skill metadata & triggers
+    ├── agents/                  # Skill UI metadata
+    ├── scripts/                 # Scaffold, validate, benchmark helpers
+    ├── evals/                   # Test cases
+    ├── templates/               # Scaffold templates
+    └── references/              # विस्तृत pattern docs
+```
+
+## Skills कैसे काम करती हैं
+
+प्रत्येक skill एक standard structure का पालन करती है:
+
+1. **SKILL.md** — Entry point। YAML frontmatter (name, description for triggering) और agent के लिए Markdown instructions शामिल हैं।
+2. **references/** — आवश्यकता के अनुसार context में load की जाने वाली अतिरिक्त दस्तावेज़।
+3. **templates/** — वे starting templates जो skill users के लिए generate कर सकती है।
+
+Skills progressive disclosure का उपयोग करती हैं — agent को पहले केवल name + description दिखाई देता है, फिर triggered होने पर पूरा SKILL.md body load होता है, और bundled resources केवल आवश्यकता पड़ने पर ही पढ़ी जाती हैं।
+
+## सुरक्षा ऑडिट
+
+इस डायरेक्टरी की सभी फ़ाइलों का सुरक्षा ऑडिट किया गया है:
+
+- कोई backdoors, hidden URLs, या encoded payloads नहीं
+- कोई data exfiltration या hardcoded credentials नहीं
+- कोई command injection vulnerabilities नहीं
+- Scripts केवल Node.js built-in modules का उपयोग करती हैं
+- जनरेट किया गया `init.sh` detected project verification commands को चलाता है
+
+## लाइसेंस
+
+MIT

--- a/skills/README-UR.md
+++ b/skills/README-UR.md
@@ -1,0 +1,95 @@
+<p align="center">
+  <a href="README.md"><img alt="English" src="https://img.shields.io/badge/English-d9d9d9"></a>
+  <a href="README-CN.md"><img alt="简体中文" src="https://img.shields.io/badge/简体中文-d9d9d9"></a>
+  <a href="README-ZH-TW.md"><img alt="繁體中文" src="https://img.shields.io/badge/繁體中文-d9d9d9"></a>
+  <a href="README-JA.md"><img alt="日本語" src="https://img.shields.io/badge/日本語-d9d9d9"></a>
+  <a href="README-ES.md"><img alt="Español" src="https://img.shields.io/badge/Español-d9d9d9"></a>
+  <a href="README-FR.md"><img alt="Français" src="https://img.shields.io/badge/Français-d9d9d9"></a>
+  <a href="README-KO.md"><img alt="한국어" src="https://img.shields.io/badge/한국어-d9d9d9"></a>
+  <a href="README-AR.md"><img alt="العربية" src="https://img.shields.io/badge/العربية-d9d9d9"></a>
+  <a href="README-VI.md"><img alt="Tiếng_Việt" src="https://img.shields.io/badge/Tiếng_Việt-d9d9d9"></a>
+  <a href="README-DE.md"><img alt="Deutsch" src="https://img.shields.io/badge/Deutsch-d9d9d9"></a>
+  <a href="README-TR.md"><img alt="Türkçe" src="https://img.shields.io/badge/Türkçe-d9d9d9"></a>
+  <a href="README-PT-BR.md"><img alt="Português (Brasil)" src="https://img.shields.io/badge/Português (Brasil)-d9d9d9"></a>
+  <a href="README-UK.md"><img alt="Українська" src="https://img.shields.io/badge/Українська-d9d9d9"></a>
+  <a href="README-HI.md"><img alt="हिन्दी" src="https://img.shields.io/badge/Hindi-d9d9d9"></a>
+  <a href="README-UR.md"><img alt="اردو" src="https://img.shields.io/badge/اردو-d9d9d9"></a>
+</p>
+
+# Skills
+
+یہ ڈائریکٹری Learn Harness Engineering پراجیکٹ کے لیے دوبارہ استعمال ہونے والی AI agent skills پر مشتمل ہے۔ ہر skill ایک self-contained prompt template ہے جسے AI coding agents (Claude Code, Codex, Cursor, Windsurf وغیرہ) مخصوص کاموں کو انجام دینے کے لیے load کر سکتے ہیں۔
+
+## دستیاب Skills
+
+### harness-creator
+
+AI coding agents کے لیے production harness engineering skill۔ agent harness files (AGENTS.md, feature lists, verification workflows, session continuity mechanisms) بنانے، جانچنے اور بہتر بنانے میں مدد کرتا ہے۔
+
+- **7 reference patterns**: Memory Persistence, Skill Runtime, Context Engineering, Tool Registry, Multi-Agent Coordination, Lifecycle & Bootstrap, Gotchas
+- **Templates**: AGENTS.md/CLAUDE.md, feature-list.json, init.sh, progress.md, session-handoff.md
+- **Scripts**: scaffold, validate, render HTML assessment, run structural benchmark
+- **10 built-in eval test cases**
+
+مکمل دستاویزات کے لیے [harness-creator/README.md](harness-creator/README.md) دیکھیں۔
+
+## harness-creator کیسے بنایا گیا
+
+`harness-creator` skill کو **skill-creator** methodology کے ذریعے تیار کیا گیا تھا — agent skills بنانے، جانچنے اور ان پر iterate کرنے کے لیے Anthropic کا سرکاری meta-skill۔ skill-creator ایک منظم workflow (draft → test → evaluate → iterate) فراہم کرتا ہے جس میں built-in eval runners، graders اور ایک benchmark viewer شامل ہیں۔
+
+- **skill-creator source**: [anthropics/skills — skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator)
+- **Anthropic Claude Code skills docs**: [anthropics/claude-code — plugin-dev/skills](https://github.com/anthropics/claude-code/tree/main/plugins/plugin-dev/skills)
+
+## ڈائریکٹری کا ڈھانچہ
+
+```
+skills/
+├── README.md                    # یہ فائل
+├── README-CN.md                 # چینی نسخہ
+├── README-ZH-TW.md              # روایتی چینی نسخہ
+├── README-JA.md                 # جاپانی نسخہ
+├── README-ES.md                 # ہسپانوی نسخہ
+├── README-FR.md                 # فرانسیسی نسخہ
+├── README-AR.md                 # عربی نسخہ
+├── README-VI.md                 # ویتنامی نسخہ
+├── README-DE.md                 # جرمن نسخہ
+├── README-TR.md                 # ترکی نسخہ
+├── README-PT-BR.md              # پرتگیزی (برازیل) نسخہ
+├── README-UK.md                 # یوکرینی نسخہ
+├── README-HI.md                 # ہندی نسخہ
+├── README-UR.md                 # اردو نسخہ
+└── harness-creator/             # Harness engineering skill
+    ├── SKILL.md                 # مرکزی skill definition
+    ├── SKILL.md.en              # صرف انگریزی نسخہ
+    ├── README.md                # تفصیلی دستاویزات
+    ├── metadata.json            # Skill metadata & triggers
+    ├── agents/                  # Skill UI metadata
+    ├── scripts/                 # Scaffold, validate, benchmark helpers
+    ├── evals/                   # Test cases
+    ├── templates/               # Scaffold templates
+    └── references/              # تفصیلی pattern docs
+```
+
+## Skills کیسے کام کرتی ہیں
+
+ہر skill ایک معیاری ڈھانچے کی پیروی کرتی ہے:
+
+1. **SKILL.md** — Entry point۔ YAML frontmatter (name، triggering کے لیے description) اور agent کے لیے Markdown instructions پر مشتمل ہے۔
+2. **references/** — ضرورت کے مطابق context میں load ہونے والی اضافی دستاویزات۔
+3. **templates/** — وہ starting templates جو skill صارفین کے لیے generate کر سکتی ہے۔
+
+Skills progressive disclosure استعمال کرتی ہیں — agent کو پہلے صرف name + description نظر آتا ہے، پھر trigger ہونے پر مکمل SKILL.md body load ہوتا ہے اور bundled resources صرف ضرورت پڑنے پر پڑھی جاتی ہیں۔
+
+## سیکیورٹی آڈٹ
+
+اس ڈائریکٹری میں موجود تمام فائلوں کا سیکیورٹی آڈٹ کیا جا چکا ہے:
+
+- کوئی backdoors، hidden URLs یا encoded payloads نہیں
+- کوئی data exfiltration یا hardcoded credentials نہیں
+- کوئی command injection vulnerabilities نہیں
+- Scripts صرف Node.js built-in modules استعمال کرتی ہیں
+- Generated `init.sh` detected project verification commands چلاتا ہے
+
+## لائسنس
+
+MIT

--- a/skills/README.md
+++ b/skills/README.md
@@ -12,6 +12,8 @@
   <a href="README-TR.md"><img alt="Türkçe" src="https://img.shields.io/badge/Türkçe-d9d9d9"></a>
   <a href="README-PT-BR.md"><img alt="Português (Brasil)" src="https://img.shields.io/badge/Português (Brasil)-d9d9d9"></a>
   <a href="README-UK.md"><img alt="Українська" src="https://img.shields.io/badge/Українська-d9d9d9"></a>
+  <a href="README-HI.md"><img alt="हिन्दी" src="https://img.shields.io/badge/Hindi-d9d9d9"></a>
+  <a href="README-UR.md"><img alt="اردو" src="https://img.shields.io/badge/اردو-d9d9d9"></a>
 </p>
 
 # Skills
@@ -54,6 +56,7 @@ skills/
 ├── README-TR.md                 # Turkish version
 ├── README-PT-BR.md              # Portuguese (Brazil) version
 ├── README-UK.md                 # Ukrainian version
+├── README-HI.md                 # Hindi version
 └── harness-creator/             # Harness engineering skill
     ├── SKILL.md                 # Main skill definition
     ├── SKILL.md.en              # English-only version


### PR DESCRIPTION
## Summary

- Add Hindi README translation
- Add Urdu README translation
- Add Hindi and Urdu entries to the language selector

No changes were made to the existing skill implementation.