### PR TITLE
fix: add missing harness-designs nav item for Spanish locale

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1061,6 +1061,7 @@ export default withMermaid(
           resources: "Biblioteca",
           skills: "Skills",
           resourceLibrary: "Biblioteca de recursos",
+          harnessDesign: "Análisis de los harness más avanzados",
           tryHarness: "Try Harness ↗",
           outline: "En esta página",
           prev: "Anterior",


### PR DESCRIPTION
## Summary
Fixes missing navigation item for the Frontier Harness Design Breakdowns section in the Spanish version of the site.

## Issue
While browsing the Spanish version of the site, I noticed that the "Análisis de los harness más avanzados" section wasn't showing up in the navigation menu, even though all the content is fully translated and exists at `/docs/es/harness-designs/`.

## Changes
- Added `harnessDesign: "Análisis de los harness más avanzados"` to the Spanish locale configuration in `config.mts`

## Testing
- ✅ Verified `npm run docs:build` completes successfully
- ✅ Tested locally with `npm run docs:dev` - section now appears in Spanish navigation
- ✅ Confirmed all Spanish harness-designs pages are accessible